### PR TITLE
WIP Bundle Rewrite

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -119,7 +119,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f4fff0c3c247502a13bde71b41f5b5ff373e4ba2aab32802e334d89382b57d4b"
+  digest = "1:d79af33e877079dedbea448d930d659b077011f761a255f10c2fddd4859a2c87"
   name = "github.com/docker/docker"
   packages = [
     "api",

--- a/cmd/duffle/bundle.go
+++ b/cmd/duffle/bundle.go
@@ -22,6 +22,7 @@ func newBundleCmd(w io.Writer) *cobra.Command {
 		newBundleSignCmd(w),
 		newBundleVerifyCmd(w),
 		newBundleRemoveCmd(w),
+		newBundleRewriteCmd(w),
 	)
 	return cmd
 }

--- a/cmd/duffle/bundle_rewrite.go
+++ b/cmd/duffle/bundle_rewrite.go
@@ -20,9 +20,7 @@ import (
 type bundleRewriteCmd struct {
 	out            io.Writer
 	home           home.Home
-	identity       string
 	bundleFile     string
-	outfile        string
 	skipValidation bool
 	signer         string
 }

--- a/cmd/duffle/bundle_rewrite.go
+++ b/cmd/duffle/bundle_rewrite.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/deis/duffle/pkg/bundle"
+	"github.com/deis/duffle/pkg/bundle/rewrite"
+	"github.com/deis/duffle/pkg/crypto/digest"
+	"github.com/deis/duffle/pkg/duffle/home"
+	"github.com/deis/duffle/pkg/signature"
+
+	"github.com/spf13/cobra"
+)
+
+type bundleRewriteCmd struct {
+	out            io.Writer
+	home           home.Home
+	identity       string
+	bundleFile     string
+	outfile        string
+	skipValidation bool
+	signer         string
+}
+
+func newBundleRewriteCmd(w io.Writer) *cobra.Command {
+
+	const usage = `Rewrite repository references in an existing CNAB bundle
+
+	The rewrite command takes a local CNAB bundle.json file and rewrites the invocation
+	image and any images defined in the images array of the bundle.json file. The command will also
+	update file references for the images. Images will also be retagged. Docker images must exist locally.
+	
+	The repository argument will be used to rewrite the image.
+	
+	Example:
+			$ duffle rewrite BUNDLENAME deis/example
+	
+			Running this command against a bundle.json with an invocation image defined as cnab/hellohelm:latest
+			will result in the bundle.json being rewritten to deis/example/hellohelm:latest
+	
+	After rewriting a bundle, you will need to push the newly tagged images.
+	`
+
+	rw := bundleRewriteCmd{out: w}
+
+	cmd := &cobra.Command{
+		Use:   "rewrite BUNDLE NEW_REGISTRY",
+		Short: "rewrite repository references in bundle",
+		Long:  usage,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rw.home = home.Home(homePath())
+			w := cmd.OutOrStdout()
+			bundleFile, newRegistry, err := validateRewriteArgs(args, rw.bundleFile, w, rw.skipValidation)
+			if err != nil {
+				return err
+			}
+			bun, err := loadBundle(bundleFile, rw.skipValidation)
+			if err != nil {
+				return err
+			}
+			rewriter, err := rewrite.New(w)
+			if err != nil {
+				return err
+			}
+			ctx := context.Background()
+			err = rewriter.Rewrite(ctx, bun, newRegistry)
+			if err != nil {
+				fmt.Fprintf(w, "error creating bundle rewriter: %s\n", err)
+				return err
+			}
+			digest, err := rw.rewriteBundle(bun)
+			if err != nil {
+				fmt.Fprintf(w, "error rewriting bundle: %s\n", err)
+				return err
+			}
+			// record the new bundle in repositories.json
+			if err := recordBundleReference(rw.home, bun.Name, bun.Version, digest); err != nil {
+				return fmt.Errorf("could not record bundle: %v", err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&rw.signer, "user", "u", "", "the user ID of the signing key to use. Format is either email address or 'NAME (COMMENT) <EMAIL>'")
+	cmd.Flags().BoolVarP(&rw.skipValidation, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
+	cmd.Flags().StringVarP(&rw.bundleFile, "file", "f", "", "path to bundle file to sign")
+
+	return cmd
+}
+
+func validateRewriteArgs(args []string, bundleFile string, w io.Writer, insecure bool) (string, string, error) {
+	switch {
+	case len(args) < 1:
+		return "", "", errors.New("this command requires at least one argument: REGISTRY (the new registry name). It also requires a BUNDLE (CNAB bundle name) or file (using -f)\nValid inputs:\n\t$ duffle bundle rewrite BUNDLE REGISTRY\n\t$ duffle bundle rewrite REGISTRY -f path-to-bundle.json")
+	case len(args) == 2 && bundleFile != "":
+		return "", "", errors.New("please use either -f or specify a BUNDLE, but not both")
+	case len(args) < 2 && bundleFile == "":
+		return "", "", errors.New("required arguments are BUNDLE (CNAB bundle name) or file and REGISTRY (Docker Registry)")
+	case len(args) == 2:
+		bun, err := loadOrPullBundle(args[0], insecure)
+		return bun, args[1], err
+	}
+	return bundleFile, args[0], nil
+}
+
+func (b bundleRewriteCmd) rewriteBundle(bf *bundle.Bundle) (string, error) {
+	kr, err := signature.LoadKeyRing(b.home.SecretKeyRing())
+	if err != nil {
+		return "", fmt.Errorf("cannot load keyring: %s", err)
+	}
+
+	if kr.Len() == 0 {
+		return "", errors.New("no signing keys are present in the keyring")
+	}
+
+	// Default to the first key in the ring unless the user specifies otherwise.
+	key := kr.Keys()[0]
+	if b.signer != "" {
+		key, err = kr.Key(b.signer)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	sign := signature.NewSigner(key)
+	data, err := sign.Clearsign(bf)
+	data = append(data, '\n')
+	if err != nil {
+		return "", fmt.Errorf("cannot sign bundle: %s", err)
+	}
+
+	digest, err := digest.OfBuffer(data)
+	if err != nil {
+		return "", fmt.Errorf("cannot compute digest from bundle: %v", err)
+	}
+
+	return digest, ioutil.WriteFile(filepath.Join(b.home.Bundles(), digest), data, 0644)
+}

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -45,8 +45,9 @@ func (b Bundle) WriteTo(w io.Writer) (int64, error) {
 
 // LocationRef specifies a location within the invocation package
 type LocationRef struct {
-	Path  string `json:"path" mapstructure:"path"`
-	Field string `json:"field" mapstructure:"field"`
+	Path     string `json:"path" mapstructure:"path"`
+	Field    string `json:"field" mapstructure:"field"`
+	Template string `json:"template,omitempty" toml:"template"`
 }
 
 // BaseImage contains fields shared across image types

--- a/pkg/bundle/replacement/jsonreplacer.go
+++ b/pkg/bundle/replacement/jsonreplacer.go
@@ -53,3 +53,19 @@ func (m jsonDocMap) asInstance(value interface{}) (docmap, bool) {
 	}
 	return jsonDocMap{}, false
 }
+
+func (r jsonReplacer) Retrieve(source string, selector string) (string, error) {
+	dict := make(map[string]interface{})
+	err := json.Unmarshal([]byte(source), &dict)
+
+	if err != nil {
+		return "", err
+	}
+
+	selectorPath := parseSelector(selector)
+	val, err := findIn(jsonDocMap(dict), selectorPath)
+	if err != nil {
+		return "", err
+	}
+	return val, nil
+}

--- a/pkg/bundle/replacement/replacer.go
+++ b/pkg/bundle/replacement/replacer.go
@@ -5,6 +5,7 @@ import "errors"
 // Replacer replaces the values of fields matched by a selector.
 type Replacer interface {
 	Replace(source string, selector string, value string) (string, error)
+	Retrieve(source string, selector string) (string, error)
 }
 
 var (

--- a/pkg/bundle/replacement/utils.go
+++ b/pkg/bundle/replacement/utils.go
@@ -1,6 +1,7 @@
 package replacement
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -33,4 +34,35 @@ func replaceIn(dict docmap, selectorPath []string, value string) error {
 	rest := selectorPath[1:]
 
 	return replaceIn(entryDict, rest, value)
+}
+
+func findIn(dict docmap, selectorPath []string) (string, error) {
+	entry, ok := dict.get(selectorPath[0])
+	if !ok {
+		return "", ErrSelectorNotFound
+	}
+
+	if len(selectorPath) == 1 {
+		val := fmt.Sprintf("%v", entry)
+		return val, nil
+	}
+
+	entryDict, ok := dict.asInstance(entry)
+	if !ok {
+		return "", ErrSelectorNotFound // Because we have reached a terminal with some of the selectorPath to go
+	}
+	rest := selectorPath[1:]
+
+	return findIn(entryDict, rest)
+}
+
+// GetReplacer gets an appropriate replacer based on file
+func GetReplacer(path string) Replacer {
+	if strings.Contains(path, ".yaml") || strings.Contains(path, ".yml") {
+		return NewYAMLReplacer()
+	} else if strings.Contains(path, ".json") {
+		return NewJSONReplacer("\t")
+	} else {
+		return nil
+	}
 }

--- a/pkg/bundle/replacement/yamlreplacer.go
+++ b/pkg/bundle/replacement/yamlreplacer.go
@@ -50,3 +50,18 @@ func (m yamlDocMap) asInstance(value interface{}) (docmap, bool) {
 	}
 	return yamlDocMap{}, false
 }
+
+func (r yamlReplacer) Retrieve(source string, selector string) (string, error) {
+	dict := make(map[interface{}]interface{})
+	err := yaml.Unmarshal([]byte(source), dict)
+
+	if err != nil {
+		return "", err
+	}
+	selectorPath := parseSelector(selector)
+	val, err := findIn(yamlDocMap(dict), selectorPath)
+	if err != nil {
+		return "", err
+	}
+	return val, nil
+}

--- a/pkg/bundle/rewrite/config/context.go
+++ b/pkg/bundle/rewrite/config/context.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/cli/cli/command"
+	cliflags "github.com/docker/cli/cli/flags"
+
+	"github.com/spf13/afero"
+)
+
+type Context struct {
+	DockerClient *command.DockerCli //todo: try and narrow this down so it's mockable
+	FileSystem   *afero.Afero
+}
+
+func New() (*Context, error) {
+	cli := command.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, false)
+	if err := cli.Initialize(cliflags.NewClientOptions()); err != nil {
+		return nil, err
+	}
+	if cli == nil {
+		fmt.Printf("well this is unfortunate")
+	}
+	return &Context{
+		DockerClient: cli,
+		FileSystem:   &afero.Afero{Fs: afero.NewOsFs()},
+	}, nil
+}

--- a/pkg/bundle/rewrite/images.go
+++ b/pkg/bundle/rewrite/images.go
@@ -1,0 +1,233 @@
+package rewrite
+
+import (
+	"archive/tar"
+	//	"bufio"
+	//	"bytes"
+	"context"
+	"fmt"
+	"io"
+	//"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/registry"
+)
+
+func (r *Rewriter) getRepoInfo(qualifiedImage string) (*registry.RepositoryInfo, error) {
+	ref, err := reference.ParseNormalizedNamed(qualifiedImage)
+	if err != nil {
+		return nil, err
+	}
+	return registry.ParseRepositoryInfo(ref)
+}
+
+func (r *Rewriter) pullImageIfNeeded(ctx context.Context, qualifiedImage string) error {
+	cli := r.Context.DockerClient.Client()
+	if cli == nil {
+		return fmt.Errorf("unable to obtain docker client")
+	}
+	_, _, err := r.Context.DockerClient.Client().ImageInspectWithRaw(ctx, qualifiedImage)
+	if client.IsErrNotFound(err) {
+		repoInfo, err := r.getRepoInfo(qualifiedImage)
+		if err != nil {
+			return err
+		}
+		authConfig := command.ResolveAuthConfig(ctx, r.Context.DockerClient, repoInfo.Index)
+		encodedAuth, err := command.EncodeAuthToBase64(authConfig)
+		if err != nil {
+			return err
+		}
+		options := types.ImagePullOptions{
+			RegistryAuth: encodedAuth,
+		}
+		responseBody, err := r.Context.DockerClient.Client().ImagePull(ctx, qualifiedImage, options)
+		if err != nil {
+			return err
+		}
+		defer responseBody.Close()
+		return jsonmessage.DisplayJSONMessagesStream(
+			responseBody,
+			r.Context.DockerClient.Out(),
+			r.Context.DockerClient.Out().FD(),
+			false, //r.Context.DockerClient.Out().IsTerminal(),
+			nil,
+		)
+	} else if err != nil {
+		fmt.Fprintf(r.Writer, "there was an error pulling: %s", err)
+		return err
+	}
+	return nil
+}
+
+func (r *Rewriter) createContainer(ctx context.Context, image string) (string, error) {
+	cfg := &container.Config{
+		Image: image,
+	}
+	hostCfg := &container.HostConfig{AutoRemove: true}
+
+	resp, err := r.Context.DockerClient.Client().ContainerCreate(ctx, cfg, hostCfg, nil, "")
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+func (r *Rewriter) getTar(ctx context.Context, containerID string, src string) (io.Reader, error) {
+	rdr, wtr := io.Pipe()
+	tw := tar.NewWriter(wtr)
+	go func() {
+		r.Context.FileSystem.Walk(src, func(file string, fi os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			target := strings.Replace(file, src, "", -1)
+			if target == "" {
+				return nil
+			}
+			header, err := tar.FileInfoHeader(fi, fi.Name())
+			if err != nil {
+				return fmt.Errorf("couldn't make header: %s", err)
+			}
+			header.Name = strings.TrimPrefix(target, string(filepath.Separator))
+			err = tw.WriteHeader(header)
+			if err != nil {
+				return fmt.Errorf("couldn't write header: %s", err)
+			}
+			if !fi.Mode().IsRegular() {
+				return nil
+			}
+			f, err := r.Context.FileSystem.Open(file)
+			if err != nil {
+				return fmt.Errorf("couldn't read file: %s", err)
+
+			}
+			if _, err := io.Copy(tw, f); err != nil {
+				return fmt.Errorf("couldnt copy file: %s", err)
+			}
+			return nil
+		})
+		wtr.Close()
+	}()
+	return rdr, nil
+}
+
+func (r *Rewriter) copyToContainerFromFileSystem(ctx context.Context, containerID string, src string) error {
+	rdr, err := r.getTar(ctx, containerID, src)
+	if err != nil {
+		return err
+	}
+	return r.Context.DockerClient.Client().CopyToContainer(ctx, containerID, "/", rdr, types.CopyToContainerOptions{
+		AllowOverwriteDirWithFile: true,
+	})
+}
+
+func (r *Rewriter) copyFromContainerToFileSystem(ctx context.Context, containerID string, dest string) error {
+
+	rdr, _, err := r.Context.DockerClient.Client().CopyFromContainer(ctx, containerID, "/cnab")
+	if err != nil {
+		return err
+	}
+	tr := tar.NewReader(rdr)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		path := filepath.Join(dest, header.Name)
+		info := header.FileInfo()
+		if info.IsDir() {
+			if err = r.Context.FileSystem.MkdirAll(path, info.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+		f, err := r.Context.FileSystem.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(f, tr)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Rewriter) commitContainer(ctx context.Context, containerID string, name string) (string, error) {
+	commitOptions := types.ContainerCommitOptions{
+		Reference: name,
+	}
+	resp, err := r.Context.DockerClient.Client().ContainerCommit(ctx, containerID, commitOptions)
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+func (r *Rewriter) stopContainer(ctx context.Context, containerID string) error {
+	return r.Context.DockerClient.Client().ContainerRemove(ctx, containerID, types.ContainerRemoveOptions{})
+}
+
+func (r *Rewriter) replaceRepository(image string, repository string) (string, error) {
+	dr, err := getDockerReference(image)
+	if err != nil {
+		return "", err
+	}
+	if dr.Tag != "" {
+		return fmt.Sprintf("%s/%s:%s", repository, dr.Image, dr.Tag), nil
+	}
+	return fmt.Sprintf("%s/%s", repository, dr.Image), nil
+
+}
+
+func (r *Rewriter) tagImage(ctx context.Context, oldImage string, newImage string) error {
+	return r.Context.DockerClient.Client().ImageTag(ctx, oldImage, newImage)
+}
+
+func getDockerReference(ref string) (*dockerReference, error) {
+	dr := dockerReference{}
+	r, err := reference.Parse(ref)
+	if err != nil {
+		return nil, err
+	}
+	dr.setImageAndRepo(r)
+	dr.setTag(r)
+	return &dr, nil
+}
+
+type dockerReference struct {
+	Repo  string
+	Image string
+	Tag   string
+}
+
+func (d *dockerReference) setImageAndRepo(ref reference.Reference) {
+	named, ok := ref.(reference.Named)
+	if ok {
+		name := named.Name()
+		if strings.LastIndex(name, "/") == -1 {
+			d.Image = name
+		} else {
+			d.Repo = name[:strings.LastIndex(name, "/")]
+			d.Image = name[strings.LastIndex(name, "/")+1:]
+		}
+	}
+}
+
+func (d *dockerReference) setTag(ref reference.Reference) {
+	tagged, ok := ref.(reference.Tagged)
+	if ok {
+		d.Tag = tagged.Tag()
+	}
+}

--- a/pkg/bundle/rewrite/images_test.go
+++ b/pkg/bundle/rewrite/images_test.go
@@ -1,0 +1,1 @@
+package rewrite

--- a/pkg/bundle/rewrite/rewriter.go
+++ b/pkg/bundle/rewrite/rewriter.go
@@ -1,0 +1,247 @@
+package rewrite
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/deis/duffle/pkg/bundle"
+	"github.com/deis/duffle/pkg/bundle/replacement"
+	"github.com/deis/duffle/pkg/bundle/rewrite/config"
+)
+
+// // Rewriter is an interface that is used to rewrite elements of a CNAB bundle
+// type Rewriter interface {
+// 	Rewrite(contents string, image string, ref bundle.LocationRef) (string, error)
+// 	ReplaceRepository(qualifiedImage string, repository string) (string, error)
+// 	TagImage(ctx context.Context, oldImage string, newImage string) error
+// }
+
+// Rewriter is used to rewrite elements of a CNAB bundle
+type Rewriter struct {
+	Context *config.Context
+	Writer  io.Writer
+}
+
+// NewRewriter returns a bundle rewriter
+func New(w io.Writer) (*Rewriter, error) {
+	context, err := config.New()
+	if err != nil {
+		return nil, err
+	}
+	r := &Rewriter{
+		Context: context,
+		Writer:  w,
+	}
+	return r, nil
+}
+
+//Rewrite updates all image references in a bundle to replace Docker registries
+func (r *Rewriter) Rewrite(ctx context.Context, bundle *bundle.Bundle, newRegistry string) error {
+	fmt.Fprintf(r.Writer, "Tagging Images\n")
+	// for all the referenced images, retag them
+	err := r.tagImages(ctx, bundle, newRegistry)
+	if err != nil {
+		fmt.Fprintf(r.Writer, "error tagging images: %s", err)
+		return err
+	}
+	//for each invocation image, start a container and copy the file system
+	for i, invocationImage := range bundle.InvocationImages {
+		if err := r.updateInvocationImage(ctx, &invocationImage, bundle.Images, newRegistry); err != nil {
+			return err
+		}
+		bundle.InvocationImages[i] = invocationImage
+	}
+	//then update the image contents with the refs
+	//then commit it
+	return nil
+}
+
+func (r *Rewriter) tagImages(ctx context.Context, bundle *bundle.Bundle, repo string) error {
+	for i, image := range bundle.Images {
+		if image.Image == "" {
+			return fmt.Errorf("image field not set")
+		}
+		err := r.pullImageIfNeeded(ctx, image.Image)
+		if err != nil {
+			return err
+		}
+		newImage, err := r.replaceRepository(image.Image, repo)
+		if err != nil {
+			return fmt.Errorf("unable to update image %s: %s", image.Image, err)
+		}
+		err = r.tagImage(ctx, image.Image, newImage)
+		if err != nil {
+			return fmt.Errorf("unable to retag image %s: %s", image.Image, err)
+		}
+		fmt.Fprintf(r.Writer, "Retagged '%s' to '%s'\n", image.Image, newImage)
+		bundle.Images[i].Image = newImage
+	}
+	return nil
+}
+
+func (r *Rewriter) updateInvocationImage(ctx context.Context, ii *bundle.InvocationImage, images []bundle.Image, newRegistry string) error {
+	// If the bundle's referenced images is empty, we can simply retag the image
+	err := r.pullImageIfNeeded(ctx, ii.Image)
+	if err != nil {
+		return err
+	}
+	newImage, err := r.replaceRepository(ii.Image, newRegistry)
+	if len(images) == 0 {
+		if err != nil {
+			return fmt.Errorf("unable to update invocation image name %s: %s", ii.Image, err)
+		}
+		err = r.tagImage(ctx, ii.Image, newImage)
+		if err != nil {
+			return fmt.Errorf("unable to retag invocation %s: %s", ii.Image, err)
+		}
+		ii.Image = newImage
+		return nil
+	}
+	// The bundle's referenced images is not empty, so we actually need to update the
+	// invocation image
+	err = r.updateImageReferences(ctx, ii, images, newRegistry)
+	if err != nil {
+		return err
+	}
+	ii.Image = newImage
+	return nil
+}
+
+func (r *Rewriter) updateImageReferences(ctx context.Context, ii *bundle.InvocationImage, images []bundle.Image, newRepo string) error {
+	newImage, err := r.replaceRepository(ii.Image, newRepo)
+	if err != nil {
+		return err
+	}
+	tmpDir, err := r.Context.FileSystem.TempDir("", "cnab")
+	if err != nil {
+		return fmt.Errorf("couldn't get a temp dir")
+	}
+	containerID, err := r.createContainer(ctx, ii.Image)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		r.Context.FileSystem.RemoveAll(tmpDir)
+		err := r.stopContainer(ctx, containerID)
+		if err != nil {
+			fmt.Fprintf(r.Writer, "couldn't remove container after rewrite: %s", err)
+		}
+	}()
+
+	err = r.copyFromContainerToFileSystem(ctx, containerID, tmpDir)
+	if err != nil {
+		return err
+	}
+	for _, image := range images {
+		for _, ref := range image.Refs {
+			contents, fi, err := r.loadReferenceFile(filepath.Join(tmpDir, ref.Path))
+			if err != nil {
+				return err
+			}
+			contents, err = r.rewriteFile(contents, newImage, ref)
+			if err != nil {
+				return err
+			}
+			err = r.writeReferenceFile([]byte(contents), fi, filepath.Join(tmpDir, ref.Path))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	err = r.copyToContainerFromFileSystem(ctx, containerID, tmpDir)
+	if err != nil {
+		return err
+	}
+	id, err := r.commitContainer(ctx, containerID, newImage)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(r.Writer, "Rewrote invocation image %s to %s\n", ii.Image, newImage)
+	fmt.Fprintf(r.Writer, "New image id : %s\n", id)
+	ii.Image = newImage
+	ii.Digest = id
+	return nil
+}
+
+func (r *Rewriter) rewriteFile(contents string, image string, ref bundle.LocationRef) (string, error) {
+	replacer := replacement.GetReplacer(ref.Path)
+	if replacer == nil {
+		return "", fmt.Errorf("unknown file type, unable to replace references")
+	}
+	val, err := replacer.Retrieve(contents, ref.Field)
+	if err != nil {
+		return "", fmt.Errorf("cannot read reference file: %s, %v", ref.Path, err)
+	}
+	replacement, err := getReplacementValue(image, val, ref.Template)
+	if err != nil {
+		return "", fmt.Errorf("error replacing image")
+	}
+	return replacer.Replace(contents, ref.Field, replacement)
+
+}
+
+func getReplacementValue(image string, value string, templateVal string) (string, error) {
+	imageRef, err := getDockerReference(image)
+	if err != nil {
+		return "", err
+	}
+	if templateVal != "" {
+		var replacement bytes.Buffer
+		goTemplate, err := template.New("").Option("missingkey=error").Parse(templateVal)
+		if err != nil {
+			return "", fmt.Errorf("error building template: %s", err)
+		}
+		if err = goTemplate.Execute(&replacement, imageRef); err != nil {
+			return "", fmt.Errorf("error executing template: %s", err)
+		}
+		return replacement.String(), nil
+	}
+	// This is the fallback behavior if no template is specified
+	// If a tag is not present, just include the repo / image portion of the reference
+	r, err := getDockerReference(value)
+	if err != nil {
+		return "", fmt.Errorf("invalid image reference :%s", err)
+	}
+	if r.Tag == "" {
+		return strings.Join([]string{imageRef.Repo, imageRef.Image}, "/"), nil
+	}
+	return image, nil
+}
+
+func (r *Rewriter) loadReferenceFile(path string) (string, os.FileInfo, error) {
+	fi, err := r.Context.FileSystem.Stat(path)
+	if err != nil {
+		return "", nil, err
+	}
+	refFile, err := r.Context.FileSystem.Open(path)
+	defer refFile.Close()
+	if err != nil {
+		return "", nil, fmt.Errorf("cannot open reference file: %v", err)
+	}
+	b, err := ioutil.ReadAll(refFile)
+	if err != nil {
+		return "", nil, fmt.Errorf("cannot read reference file: %v", err)
+	}
+	return string(b), fi, nil
+}
+
+func (r *Rewriter) writeReferenceFile(contents []byte, fi os.FileInfo, path string) error {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fi.Mode())
+	defer f.Close()
+	if err != nil {
+		return fmt.Errorf("cannot write reference file: %v", err)
+	}
+	_, err = f.Write(contents)
+	if err != nil {
+		return fmt.Errorf("cannot write referenc file: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Note: This PR replaces #263. 

This PR introduces a new `duffle bundle` subcommand called `rewrite`. The purpose of this command, as identified in #217, is to introduce the ability for a `duffle` user to take an existing bundle and "rewrite" all the registry references. This begins with the `images` section of the bundle. Each of these images is retagged using the specified registry prefix. Next, the "/cnab" portion of the file system of each invocation image is copied to a temp directory, and mutated to update references for each of the images in the `images` section of the bundle. These mutated files are then copied back to the invocation image and it is committed to create a new image, using the specified repository. Finally, the bundle is signed, similar to the mechanism for `duffle build`.

This PR is intended to introduce capabilities to extend import/export functionality (export -> import (rewrite on import)

Closes: #217