### PR TITLE
[WIP] Add `duffle bundle docs`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -119,7 +119,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f4fff0c3c247502a13bde71b41f5b5ff373e4ba2aab32802e334d89382b57d4b"
+  digest = "1:d79af33e877079dedbea448d930d659b077011f761a255f10c2fddd4859a2c87"
   name = "github.com/docker/docker"
   packages = [
     "api",
@@ -484,12 +484,44 @@
   revision = "418d78d0b9a7b7de3a6bbc8a23def624cc977bb2"
 
 [[projects]]
+  branch = "mdcat-pkg"
+  digest = "1:d98d4d84e38f37df847131059aaeb4857d99f05b896751393c115c2161ddc6ef"
+  name = "github.com/radu-matei/mdcat"
+  packages = ["renderer"]
+  pruneopts = "NUT"
+  revision = "2698873f8a91380392293de264a1782aee80b463"
+
+[[projects]]
   digest = "1:3fd3d634f6815f19ac4b2c5e16d28ec9aa4584d0bba25d1ee6c424d813cca22a"
   name = "github.com/renstrom/fuzzysearch"
   packages = ["fuzzy"]
   pruneopts = "NUT"
   revision = "b18e754edff4833912ef4dce9eaca885bd3f0de1"
   version = "v1.0.1"
+
+[[projects]]
+  digest = "1:926cba3a3c1cddfcfad996917e5d72fb4726536dbdc7264fa936e8c99890e558"
+  name = "github.com/russross/blackfriday"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "d3b5b032dc8e8927d31a5071b56e14c89f045135"
+  version = "v2.0.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:70675d26a4cb6facd3647a20175a4f4ade5fe950cde512ae9ae5ca3050b597e6"
+  name = "github.com/samfoo/ansi"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "b6bd2ded7189ce35bc02233b554eb56a5146af73"
+
+[[projects]]
+  branch = "master"
+  digest = "1:debf1a119378d059b68925f1796851b6855bfc2f55419a50d634ecce3eabd8e8"
+  name = "github.com/shurcooL/sanitized_anchor_name"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "86672fcb3f950f35f2e675df2240550f2a50762f"
 
 [[projects]]
   digest = "1:01252cd79aac70f16cac02a72a1067dd136e0ad6d5b597d0129cf74c739fd8d1"
@@ -705,7 +737,9 @@
     "github.com/gosuri/uitable",
     "github.com/oklog/ulid",
     "github.com/opencontainers/go-digest",
+    "github.com/radu-matei/mdcat/renderer",
     "github.com/renstrom/fuzzysearch/fuzzy",
+    "github.com/russross/blackfriday",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -500,12 +500,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:926cba3a3c1cddfcfad996917e5d72fb4726536dbdc7264fa936e8c99890e558"
+  branch = "master"
+  digest = "1:d9afa09f6a45f68ec50047f8187c9d273b1fbf507858a104064bb6d9eb2e2795"
   name = "github.com/russross/blackfriday"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "d3b5b032dc8e8927d31a5071b56e14c89f045135"
-  version = "v2.0.1"
+  revision = "abafa45cd843f4f4935c29a2e8f3d73a01820fc3"
 
 [[projects]]
   branch = "master"
@@ -514,14 +514,6 @@
   packages = ["."]
   pruneopts = "NUT"
   revision = "b6bd2ded7189ce35bc02233b554eb56a5146af73"
-
-[[projects]]
-  branch = "master"
-  digest = "1:debf1a119378d059b68925f1796851b6855bfc2f55419a50d634ecce3eabd8e8"
-  name = "github.com/shurcooL/sanitized_anchor_name"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "86672fcb3f950f35f2e675df2240550f2a50762f"
 
 [[projects]]
   digest = "1:01252cd79aac70f16cac02a72a1067dd136e0ad6d5b597d0129cf74c739fd8d1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,6 +42,11 @@
   name = "gopkg.in/yaml.v2"
   version = "2.2.1"
 
+# TODO - if PR is merged, change to revision from samfoo/mdcat
+[[override]]
+  name = "github.com/radu-matei/mdcat"
+  branch = "mdcat-pkg"
+
 [prune]
   non-go = true
   unused-packages = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,6 +42,10 @@
   name = "gopkg.in/yaml.v2"
   version = "2.2.1"
 
+[[constraint]]
+  name = "github.com/russross/blackfriday"
+  branch = "master"
+
 # TODO - if PR is merged, change to revision from samfoo/mdcat
 [[override]]
   name = "github.com/radu-matei/mdcat"

--- a/cmd/duffle/bundle.go
+++ b/cmd/duffle/bundle.go
@@ -22,6 +22,7 @@ func newBundleCmd(w io.Writer) *cobra.Command {
 		newBundleSignCmd(w),
 		newBundleVerifyCmd(w),
 		newBundleRemoveCmd(w),
+		newBundleDocsCmd(w),
 	)
 	return cmd
 }

--- a/cmd/duffle/bundle_docs.go
+++ b/cmd/duffle/bundle_docs.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/deis/duffle/pkg/driver"
 
-	"github.com/russross/blackfriday"
+	"github.com/radu-matei/mdcat/renderer"
 
-	"github.com/samfoo/mdcat/renderer"
+	"github.com/russross/blackfriday"
 
 	"github.com/spf13/cobra"
 )
@@ -44,6 +45,7 @@ func newBundleDocsCmd(w io.Writer) *cobra.Command {
 				return fmt.Errorf("cannot create temp file for bundle doc: %v", err)
 			}
 			defer tmp.Close()
+			defer os.Remove(tmp.Name())
 
 			var image string
 			for _, ii := range bun.InvocationImages {

--- a/cmd/duffle/bundle_docs.go
+++ b/cmd/duffle/bundle_docs.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/deis/duffle/pkg/driver"
+
+	"github.com/russross/blackfriday"
+
+	"github.com/samfoo/mdcat/renderer"
+
+	"github.com/spf13/cobra"
+)
+
+type bundleDocsCmd struct {
+	out        io.Writer
+	bundleFile string
+	insecure   bool
+}
+
+func newBundleDocsCmd(w io.Writer) *cobra.Command {
+	bd := &bundleDocsCmd{out: w}
+
+	cmd := &cobra.Command{
+		Use:     "docs",
+		Aliases: []string{"doc", "info"},
+		Short:   "displays bundle documentation stored in the first Docker invocation image in /cnab/app/readme",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			bundle, err := bundleFileOrArg1(args, bd.bundleFile)
+			if err != nil {
+				return err
+			}
+
+			bun, err := loadBundle(bundle, bd.insecure)
+			if err != nil {
+				return err
+			}
+
+			tmp, err := ioutil.TempFile("", "duffle-tmp-doc-")
+			if err != nil {
+				return fmt.Errorf("cannot create temp file for bundle doc: %v", err)
+			}
+			defer tmp.Close()
+
+			var image string
+			for _, ii := range bun.InvocationImages {
+				if ii.ImageType != "docker" {
+					continue
+				}
+				image = ii.Image
+			}
+			if image == "" {
+				return fmt.Errorf("no docker type invocation image found")
+			}
+
+			err = driver.CopyFromContainer(image, "/cnab/README.md", tmp)
+			if err != nil {
+				return fmt.Errorf("cannot copy from container: %v", err)
+			}
+
+			doc, err := ioutil.ReadFile(tmp.Name())
+			if err != nil {
+				return fmt.Errorf("cannot read tmp file: %v", err)
+			}
+
+			extensions := 0 |
+				blackfriday.EXTENSION_NO_INTRA_EMPHASIS |
+				blackfriday.EXTENSION_FENCED_CODE |
+				blackfriday.EXTENSION_AUTOLINK |
+				blackfriday.EXTENSION_STRIKETHROUGH |
+				blackfriday.EXTENSION_SPACE_HEADERS |
+				blackfriday.EXTENSION_HEADER_IDS |
+				blackfriday.EXTENSION_BACKSLASH_LINE_BREAK |
+				blackfriday.EXTENSION_DEFINITION_LISTS
+			output := blackfriday.Markdown(doc, &renderer.Console{}, extensions)
+
+			fmt.Printf("%s", output)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&bd.bundleFile, "file", "f", "", "path to bundle file display docs")
+	cmd.Flags().BoolVarP(&bd.insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
+
+	return cmd
+}


### PR DESCRIPTION
This PR introduces the the command `duffle bundle docs/info`, and the concept of self-contained docs for invocation images.

Currently, the spec states that _the `/cnab` directory of the invocation image MAY contain [...] a README.md or README.txt_ - if we decide to go ahead with self -contained docs for invocation images, we would modify it to be the spec-compliant equivalent of (at least) _highly recommended_.

Notes:

- this PR is currently marked as WIP because it does not yet handle all possible cases for doc files, and because of a few other items marked as `TODO` (see below).

- essentially, when executing the command, a container with the bundle's first `docker`-type invocation image is created (not run), and the documentation file is copied from the container to a temp file on disk. That file is read, then rendered as markdown on the console.

To test:
 
```console
$ duffle inspect pulumibase:0.1.0 --insecure
{
    "name": "pulumibase",
    "version": "0.1.0",
    "description": "",
    "invocationImages": [
        {
            "imageType": "docker",
            "image": "radumatei/pulumibase:0.1.0"
        }
    ],
    "images": [],
    "parameters": null,
    "credentials": null
}
$ duffle bundle docs pulumibase:0.1.0 --insecure
<rendeded markdown of https://github.com/deislabs/bundles/blob/master/pulumibase/README.md>
```

TODO:

- [ ] handle all possible documentation files
- [ ] decide if `docs` should be a directory reserved by the spec, and this command would copy it, if present.
- [ ] discuss how the visual installer would interact with this command (and the addition of flags to handle the output for renderers other than console)
- [ ] if the [PR to `samfoo/mdcat`](https://github.com/samfoo/mdcat/pull/2) is merged, switch the dependency to that - otherwise, keep the current fork.
- [ ] solve bug in renderer for `#` headers
- [ ] solve bug where the tar header is present in doc file (see below)

```
README.md
0100777 0000000 0000000 00000001356 13375572324 010553  0
ustar 00
```