### PR TITLE
fix(docs): Fix docs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Duffle: The CNAB Installer
 ![Build Status](http://badges.technosophos.me/v1/github/build/deislabs/duffle/badge.svg?branch=master)
 
-Duffle is a command line tool that allows you to install and manage CNAB bundles. To learn more about about CNAB and duffle, check out the [docs](docs/000-index.md).
+Duffle is a command line tool that allows you to install and manage CNAB bundles. To learn more about about CNAB and duffle, check out the [docs](docs/README.md).
 
 ## Getting Started
 


### PR DESCRIPTION
This fixes the link to the docs pages from the project README.md following the docs reorganisation in c6af6c42066cba5a555ae5e714c92d139df77f5b