### PR TITLE
Adding apk update to create Dockerfile

### DIFF
--- a/pkg/duffle/manifest/create.go
+++ b/pkg/duffle/manifest/create.go
@@ -21,6 +21,7 @@ fi
 
 const dockerfileContent = `FROM alpine:latest
 
+RUN apk update
 RUN apk add -u bash
 
 COPY Dockerfile /cnab/Dockerfile


### PR DESCRIPTION
This is also needed for the default Dockerfile created by `duffle create` to run without breaking