### PR TITLE
Adding -r to duffle show command

### DIFF
--- a/docs/guides/bundle-guide.md
+++ b/docs/guides/bundle-guide.md
@@ -94,7 +94,7 @@ $ duffle build .
 After the bundle has been built, we can inspect the bundle:
 
 ```console
-$ duffle show helloworld:0.1.0
+$ duffle show helloworld:0.1.0 -r
 -----BEGIN PGP SIGNED MESSAGE-----
 Hash: SHA256
 


### PR DESCRIPTION
This is needed to see the PGP signature that the rest of the documentation suggests is there.