### PR TITLE
Use provided writer with Fprintf in place of fmt.Printf

### DIFF
--- a/cmd/duffle/run.go
+++ b/cmd/duffle/run.go
@@ -78,7 +78,7 @@ Credentials and parameters may be passed to the bundle during a target action.
 				Action: target,
 			}
 
-			fmt.Printf("Executing custom action %q for release %q", target, claimName)
+			fmt.Fprintf(w, "Executing custom action %q for release %q", target, claimName)
 			err = action.Run(&c, creds, cmd.OutOrStdout())
 			if actionDef := c.Bundle.Actions[target]; !actionDef.Modifies {
 				// Do not store a claim for non-mutating actions.

--- a/pkg/ohai/ohai.go
+++ b/pkg/ohai/ohai.go
@@ -6,18 +6,18 @@ import (
 )
 
 // Ohai displays an informative message.
-func Ohai(a ...interface{}) (int, error) {
-	return Ohaif("%s", a...)
+func Ohai(w io.Writer, a ...interface{}) (int, error) {
+	return Ohaif(w, "%s", a...)
 }
 
 // Ohaif displays an informative message.
-func Ohaif(format string, a ...interface{}) (int, error) {
-	return fmt.Printf(fmt.Sprintf("==> %s", format), a...)
+func Ohaif(w io.Writer, format string, a ...interface{}) (int, error) {
+	return fmt.Fprintf(w, fmt.Sprintf("==> %s", format), a...)
 }
 
 // Ohailn displays an informative message.
-func Ohailn(a ...interface{}) (int, error) {
-	return Ohaif("%s\n", a...)
+func Ohailn(w io.Writer, a ...interface{}) (int, error) {
+	return Ohaif(w, "%s\n", a...)
 }
 
 // Fohai displays an informative message.
@@ -36,18 +36,18 @@ func Fohailn(w io.Writer, a ...interface{}) (int, error) {
 }
 
 // Success displays a success message.
-func Success(a ...interface{}) (int, error) {
-	return Successf("%s", a...)
+func Success(w io.Writer, a ...interface{}) (int, error) {
+	return Successf(w, "%s", a...)
 }
 
 // Successf displays a success message.
-func Successf(format string, a ...interface{}) (int, error) {
-	return fmt.Printf(fmt.Sprintf("✓✓✓ %s", format), a...)
+func Successf(w io.Writer, format string, a ...interface{}) (int, error) {
+	return fmt.Fprintf(w, fmt.Sprintf("✓✓✓ %s", format), a...)
 }
 
 // Successln displays a success message.
-func Successln(a ...interface{}) (int, error) {
-	return Successf("%s\n", a...)
+func Successln(w io.Writer, a ...interface{}) (int, error) {
+	return Successf(w, "%s\n", a...)
 }
 
 // Fsuccess displays an informative message.


### PR DESCRIPTION
I saw the "good first issue" on #370 and thought I'd try my hand. I think these are the changes that were meant. I just added an `io.Writer` to each of them to accommodate the change from `fmt.Printf` to `fmt.Fprintf`. Is this correct? 

closing #370 