### PR TITLE
feat: use Canonical JSON

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1207,6 +1207,7 @@
     "github.com/docker/docker/pkg/term",
     "github.com/docker/docker/registry",
     "github.com/docker/go-connections/tlsconfig",
+    "github.com/docker/go/canonical/json",
     "github.com/ghodss/yaml",
     "github.com/gosuri/uitable",
     "github.com/oklog/ulid",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,3 +50,6 @@
   non-go = true
   unused-packages = true
   go-tests = true
+[[constraint]]
+  name = "github.com/docker/go"
+  version = "1.5.1-1"

--- a/cmd/duffle/create_test.go
+++ b/cmd/duffle/create_test.go
@@ -44,37 +44,9 @@ func TestCreateCmd(t *testing.T) {
 		t.Error(err)
 	}
 
-	expected := `{
-    "name": "test-bundle",
-    "version": "0.1.0",
-    "description": "A short description of your bundle",
-    "keywords": [
-        "test-bundle",
-        "cnab",
-        "tutorial"
-    ],
-    "maintainers": [
-        {
-            "name": "John Doe",
-            "email": "john.doe@example.com",
-            "url": "https://example.com"
-        },
-        {
-            "name": "Jane Doe",
-            "email": "jane.doe@example.com",
-            "url": "https://example.com"
-        }
-    ],
-    "invocationImages": {
-        "cnab": {
-            "name": "cnab",
-            "builder": "docker",
-            "configuration": {
-                "registry": "deislabs"
-            }
-        }
-    }
-}`
+	// This is the Canonical JSON representation. http://wiki.laptop.org/go/Canonical_JSON
+	expected := `{"description":"A short description of your bundle","invocationImages":{"cnab":{"builder":"docker","configuration":{"registry":"deislabs"},"name":"cnab"}},"keywords":["test-bundle","cnab","tutorial"],"maintainers":[{"email":"john.doe@example.com","name":"John Doe","url":"https://example.com"},{"email":"jane.doe@example.com","name":"Jane Doe","url":"https://example.com"}],"name":"test-bundle","version":"0.1.0"}`
+
 	if string(mbytes) != expected {
 		t.Errorf("Expected duffle.json output to look like this:\n\n%s\n\nGot:\n\n%s", expected, string(mbytes))
 	}

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -1,13 +1,14 @@
 package bundle
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/docker/go/canonical/json"
 )
 
 // Bundle is a CNAB metadata document
@@ -40,7 +41,7 @@ func ParseReader(r io.Reader) (Bundle, error) {
 // WriteFile serializes the bundle and writes it to a file as JSON.
 func (b Bundle) WriteFile(dest string, mode os.FileMode) error {
 	// FIXME: The marshal here should exactly match the Marshal in the signature code.
-	d, err := json.MarshalIndent(b, "", "    ")
+	d, err := json.MarshalCanonical(b)
 	if err != nil {
 		return err
 	}
@@ -49,7 +50,7 @@ func (b Bundle) WriteFile(dest string, mode os.FileMode) error {
 
 // WriteTo writes unsigned JSON to an io.Writer using the standard formatting.
 func (b Bundle) WriteTo(w io.Writer) (int64, error) {
-	d, err := json.MarshalIndent(b, "", "    ")
+	d, err := json.MarshalCanonical(b)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -1,9 +1,10 @@
 package driver
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/docker/go/canonical/json"
 )
 
 // ImageType constants provide some of the image types supported

--- a/pkg/duffle/manifest/create.go
+++ b/pkg/duffle/manifest/create.go
@@ -1,10 +1,11 @@
 package manifest
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/docker/go/canonical/json"
 
 	"github.com/deislabs/duffle/pkg/bundle"
 )
@@ -62,7 +63,7 @@ func Scaffold(path string) error {
 		},
 	}
 
-	d, err := json.MarshalIndent(m, "", "    ")
+	d, err := json.MarshalCanonical(m)
 	if err != nil {
 		return err
 	}

--- a/pkg/signature/signature.go
+++ b/pkg/signature/signature.go
@@ -3,9 +3,10 @@ package signature
 import (
 	"bytes"
 	"crypto"
-	"encoding/json"
 	"errors"
 	"io"
+
+	"github.com/docker/go/canonical/json"
 
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
@@ -129,7 +130,7 @@ func (s *Signer) prepareSign(b *bundle.Bundle) (*packet.PrivateKey, []byte, erro
 
 	// We want a canonical representation of a serialized bundle, which is why we
 	// take the object.
-	data, err := json.MarshalIndent(b, "", "  ")
+	data, err := json.MarshalCanonical(b)
 	if err != nil {
 		return pk, res, err
 	}


### PR DESCRIPTION
This switches Duffle to use Canonical JSON, which provides JSON ordering
that is conducive to hashing. http://wiki.laptop.org/go/Canonical_JSON

This will increase interoperability with other languages and platforms,
and match the ordering produced by security tools like Notary.

Note that this change does not impact:

- Claims (still stored as regular JSON)
- Drivers (still receive regular JSON)
- Repo (still uses regular JSON)