### PR TITLE
Fix not installing when invocation image not present

### DIFF
--- a/pkg/driver/docker_driver.go
+++ b/pkg/driver/docker_driver.go
@@ -83,12 +83,9 @@ func pullImage(ctx context.Context, cli command.Cli, image string) error {
 		return err
 	}
 	defer responseBody.Close()
-	return jsonmessage.DisplayJSONMessagesStream(
-		responseBody,
-		cli.Out(),
-		cli.Out().FD(),
-		cli.Out().IsTerminal(),
-		nil)
+
+	// passing isTerm = false here because of https://github.com/Nvveen/Gotty/pull/1
+	return jsonmessage.DisplayJSONMessagesStream(responseBody, cli.Out(), cli.Out().FD(), false, nil)
 }
 
 func (d *DockerDriver) initializeDockerCli() (command.Cli, error) {


### PR DESCRIPTION
On Debian at least, it turns out we are hitting https://github.com/Nvveen/Gotty/pull/1 - workaround is to pass `isTerm = false` to `jsonmessage.DisplayJSONMessagesStream()`.

closes #596 