### PR TITLE
ref(cmd/duffle): export bundle ref or file

### DIFF
--- a/cmd/duffle/export_test.go
+++ b/cmd/duffle/export_test.go
@@ -53,15 +53,15 @@ func TestExportSetup(t *testing.T) {
 
 	duffleHome := home.Home(tempDuffleHome)
 	exp := &exportCmd{
-		bundleRef: "foo:1.0.0",
-		dest:      tempDir,
-		home:      duffleHome,
-		out:       out,
+		bundle: "foo:1.0.0",
+		dest:   tempDir,
+		home:   duffleHome,
+		out:    out,
 	}
 
 	source, _, err := exp.setup()
 	if err != nil {
-		t.Fatal(err)
+		t.Errorf("Did not expect error but got %s", err)
 	}
 
 	expectedSource := filepath.Join(tempDuffleHome, "bundles", "foo-1.0.0.cnab")
@@ -70,16 +70,32 @@ func TestExportSetup(t *testing.T) {
 	}
 
 	expFail := &exportCmd{
-		bundleRef: "bar:1.0.0",
-		dest:      tempDir,
-		home:      duffleHome,
-		out:       out,
+		bundle: "bar:1.0.0",
+		dest:   tempDir,
+		home:   duffleHome,
+		out:    out,
 	}
 	_, _, err = expFail.setup()
 	if err == nil {
 		t.Error("Expected error, got none")
 	}
 
+	bundlepath := filepath.Join("..", "..", "tests", "testdata", "bundles", "foo.json")
+	expFile := &exportCmd{
+		bundle:       bundlepath,
+		dest:         tempDir,
+		home:         duffleHome,
+		out:          out,
+		sourceIsFile: true,
+	}
+	source, _, err = expFile.setup()
+	if err != nil {
+		t.Errorf("Did not expect error but got %s", err)
+	}
+
+	if source != bundlepath {
+		t.Errorf("Expected bundle file path to be %s, got %s", bundlepath, source)
+	}
 }
 
 func copyFile(src, dst string) (err error) {

--- a/pkg/packager/export.go
+++ b/pkg/packager/export.go
@@ -2,7 +2,6 @@ package packager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,10 +15,6 @@ import (
 
 	"github.com/deislabs/duffle/pkg/bundle"
 	"github.com/deislabs/duffle/pkg/loader"
-)
-
-var (
-	ErrDestinationNotDirectory = errors.New("Destination not directory")
 )
 
 type Exporter struct {
@@ -77,8 +72,8 @@ func (ex *Exporter) Export() error {
 	defer logsf.Close()
 
 	fi, err := os.Stat(ex.Source)
-	if err != nil && os.IsNotExist(err) {
-		return fmt.Errorf("Bundle manifest not found at %s", ex.Source)
+	if os.IsNotExist(err) {
+		return err
 	}
 	if fi.IsDir() {
 		return fmt.Errorf("Bundle manifest %s is a directory, should be a file", ex.Source)


### PR DESCRIPTION
duffle export takes one arg. It figures out if arg is
filepath or a bundle reference and then exports accordingly

resolves #582