### PR TITLE
Switch order of testing and linting in CI

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -27,8 +27,8 @@ function build(e, project) {
     `cp -a /src/.git ${localPath}`,
     `cd ${localPath}`,
     "make bootstrap",
+    "make test",
     "make lint",
-    "make test"
   ];
 
   return build


### PR DESCRIPTION
When I submit a PR, it is arguably more important for everyone to see the status of the tests - currently, if the linter fails, you don't get to see the actual test results.

This PR changes that.

cc @vdice 