### PR TITLE
Adds alias `duffle bundle show` of existing command `duffle show`

### DIFF
--- a/cmd/duffle/bundle.go
+++ b/cmd/duffle/bundle.go
@@ -19,6 +19,7 @@ func newBundleCmd(w io.Writer) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newBundleListCmd(w),
+		newBundleShowCmd(w),
 		newBundleSignCmd(w),
 		newBundleVerifyCmd(w),
 		newBundleRemoveCmd(w),

--- a/cmd/duffle/bundle_show.go
+++ b/cmd/duffle/bundle_show.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newBundleShowCmd(w io.Writer) *cobra.Command {
+	bsc := &bundleShowCmd{}
+	bsc.w = w
+
+	cmd := &cobra.Command{
+		Use:   "show NAME",
+		Short: "return low-level information on application bundles",
+		Long:  bsc.usage(true),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			bsc.name = args[0]
+
+			return bsc.run()
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&bsc.insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
+	flags.BoolVarP(&bsc.raw, "raw", "r", false, "Display the raw bundle manifest")
+
+	return cmd
+}
+
+type bundleShowCmd struct {
+	name     string
+	insecure bool
+	raw      bool
+	w        io.Writer
+}
+
+func (bsc *bundleShowCmd) usage(bundleSubCommand bool) string {
+	commandName := "show"
+	if bundleSubCommand {
+		commandName = "bundle show"
+	}
+
+	return fmt.Sprintf(` Returns information about an application bundle.
+
+	Example:
+		$ duffle %s duffle/example:0.1.0
+
+	To display unsigned bundles, pass the --insecure flag:
+		$ duffle %s duffle/unsinged-example:0.1.0 --insecure
+`, commandName, commandName)
+}
+
+func (bsc *bundleShowCmd) run() error {
+	bundleFile, err := getBundleFilepath(bsc.name, homePath(), bsc.insecure)
+	if err != nil {
+		return err
+	}
+
+	if bsc.raw {
+		f, err := os.Open(bundleFile)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(bsc.w, f)
+		return err
+	}
+
+	bun, err := loadBundle(bundleFile, bsc.insecure)
+	if err != nil {
+		return err
+	}
+
+	_, err = bun.WriteTo(bsc.w)
+
+	return err
+}

--- a/cmd/duffle/show.go
+++ b/cmd/duffle/show.go
@@ -2,63 +2,29 @@ package main
 
 import (
 	"io"
-	"os"
 
 	"github.com/spf13/cobra"
 )
 
 func newShowCmd(w io.Writer) *cobra.Command {
-	var (
-		insecure bool
-		raw      bool
-	)
-
-	const usage = ` Returns information about an application bundle.
-
-	Example:
-		$ duffle show duffle/example:0.1.0
-
-	To display unsigned bundles, pass the --insecure flag:
-		$ duffle show duffle/unsinged-example:0.1.0 --insecure
-`
+	bsc := &bundleShowCmd{}
+	bsc.w = w
 
 	cmd := &cobra.Command{
 		Use:   "show NAME",
 		Short: "return low-level information on application bundles",
-		Long:  usage,
+		Long:  bsc.usage(false),
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			bundleName := args[0]
+			bsc.name = args[0]
 
-			bundleFile, err := getBundleFilepath(bundleName, homePath(), insecure)
-			if err != nil {
-				return err
-			}
-
-			if raw {
-				f, err := os.Open(bundleFile)
-				if err != nil {
-					return err
-				}
-				defer f.Close()
-				_, err = io.Copy(w, f)
-				return err
-			}
-
-			bun, err := loadBundle(bundleFile, insecure)
-			if err != nil {
-				return err
-			}
-
-			_, err = bun.WriteTo(w)
-
-			return err
+			return bsc.run()
 		},
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVarP(&insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
-	flags.BoolVarP(&raw, "raw", "r", false, "Display the raw bundle manifest")
+	flags.BoolVarP(&bsc.insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
+	flags.BoolVarP(&bsc.raw, "raw", "r", false, "Display the raw bundle manifest")
 
 	return cmd
 }


### PR DESCRIPTION
* Refactors the contents of the `duffle show` command out into a struct.
* Invokes the common struct in both `duffle show` and `duffle bundle show` commands.

Resolves https://github.com/deislabs/duffle/issues/535