### PR TITLE
Fix missing json struct tag

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -116,7 +116,7 @@ type Action struct {
 	// Modifies indicates whether this action modifies the release.
 	//
 	// If it is possible that an action modify a release, this must be set to true.
-	Modifies bool
+	Modifies bool `json:"modifies" mapstructure:"modifies"`
 }
 
 // ValuesOrDefaults returns parameter values or the default parameter values


### PR DESCRIPTION
Modifies field is missing some struct tags, for json and mapstructure serialization.
