### PR TITLE
Proposal Implementation: Replace env var and file inputs with JSON on STDIN

### DIFF
--- a/examples/helloworld/cnab/Dockerfile
+++ b/examples/helloworld/cnab/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN apk update
-RUN apk add -u bash
+RUN apk add -u bash jq
 
 COPY Dockerfile /cnab/Dockerfile
 COPY app /cnab/app

--- a/examples/helloworld/cnab/app/run
+++ b/examples/helloworld/cnab/app/run
@@ -2,11 +2,19 @@
 
 #set -eo pipefail
 
-action=$CNAB_ACTION
-name=$CNAB_INSTALLATION_NAME
-param=${CNAB_P_HELLO:-hello}
+inputs="$(jq -r . < /dev/stdin)"
 
-echo "$param world"
+echo "inputs: $inputs"
+
+action="$(echo "$inputs" | jq -r .installation.action)"
+name="$(echo "$inputs" | jq -r .installation.name)"
+greeting="$(echo "$inputs" | jq -r .parameters.greeting)"
+names="$(echo "$inputs" | jq -r .parameters.names[])"
+
+for name in $names; do
+  echo "$greeting $name"
+done
+
 case $action in
     install)
     echo "Install action"

--- a/examples/helloworld/duffle.json
+++ b/examples/helloworld/duffle.json
@@ -1,33 +1,49 @@
 {
-    "name": "helloworld",
-    "version": "0.1.0",
-    "description": "A short description of your bundle",
-    "keywords": [
-        "helloworld",
-        "cnab",
-        "tutorial"
-    ],
-    "maintainers": [
-        {
-            "name": "John Doe",
-            "email": "john.doe@example.com",
-            "url": "https://example.com"
-        },
-        {
-            "name": "Jane Doe",
-            "email": "jane.doe@example.com",
-            "url": "https://example.com"
-        }
-    ],
-    "invocationImages": {
-        "cnab": {
-            "name": "cnab",
-            "builder": "docker",
-            "configuration": {
-                "registry": "deislabs"
-            }
-        }
-    },
-    "parameters": null,
-    "credentials": null
+   "description" : "A short description of your bundle",
+   "parameters" : {
+      "greeting" : {
+         "type" : "string",
+         "defaultValue" : "hello",
+         "description" : "the greeting echoed by the invocation image"
+      },
+      "names": {
+        "type": "array",
+        "defaultValue": ["world"],
+        "description": "the list of names to greet"
+      }
+   },
+   "actions" : {
+      "status" : {
+         "modifies" : false
+      }
+   },
+   "credentials" : {},
+   "name" : "helloworld",
+   "invocationImages" : {
+      "cnab" : {
+         "name" : "cnab",
+         "configuration" : {
+            "registry" : "deislabs"
+         },
+         "builder" : "docker"
+      }
+   },
+   "keywords" : [
+      "helloworld",
+      "cnab",
+      "tutorial"
+   ],
+   "maintainers" : [
+      {
+         "name" : "John Doe",
+         "url" : "https://example.com",
+         "email" : "john.doe@example.com"
+      },
+      {
+         "name" : "Jane Doe",
+         "email" : "jane.doe@example.com",
+         "url" : "https://example.com"
+      }
+   ],
+   "version" : "0.1.0"
 }

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -1,11 +1,9 @@
 package action
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/deislabs/duffle/pkg/bundle"
 	"github.com/deislabs/duffle/pkg/claim"
@@ -40,20 +38,7 @@ func selectInvocationImage(d driver.Driver, c *claim.Claim) (bundle.InvocationIm
 	return bundle.InvocationImage{}, errors.New("driver is not compatible with any of the invocation images in the bundle")
 }
 
-func getImageMap(b *bundle.Bundle) ([]byte, error) {
-	imgs := b.Images
-	if imgs == nil {
-		imgs = make(map[string]bundle.Image)
-	}
-	return json.Marshal(imgs)
-}
-
 func opFromClaim(action string, c *claim.Claim, ii bundle.InvocationImage, creds credentials.Set, w io.Writer) (*driver.Operation, error) {
-	env, files, err := creds.Expand(c.Bundle)
-	if err != nil {
-		return nil, err
-	}
-
 	// Quick verification that no params were passed that are not actual legit params.
 	for key := range c.Parameters {
 		if _, ok := c.Bundle.Parameters[key]; !ok {
@@ -61,45 +46,20 @@ func opFromClaim(action string, c *claim.Claim, ii bundle.InvocationImage, creds
 		}
 	}
 
-	for k, param := range c.Bundle.Parameters {
-		rawval, ok := c.Parameters[k]
-		if !ok {
-			continue
-		}
-		value := fmt.Sprintf("%v", rawval)
-		if param.Destination == nil {
-			// env is a CNAB_P_
-			env[fmt.Sprintf("CNAB_P_%s", strings.ToUpper(k))] = value
-			continue
-		}
-		if param.Destination.Path != "" {
-			files[param.Destination.Path] = value
-		}
-		if param.Destination.EnvironmentVariable != "" {
-			env[param.Destination.EnvironmentVariable] = value
-		}
-	}
-
-	imgMap, err := getImageMap(c.Bundle)
-	if err != nil {
-		return nil, fmt.Errorf("unable to generate image map: %s", err)
-	}
-	files["/cnab/app/image-map.json"] = string(imgMap)
-
-	env["CNAB_INSTALLATION_NAME"] = c.Name
-	env["CNAB_ACTION"] = action
-	env["CNAB_BUNDLE_NAME"] = c.Bundle.Name
-	env["CNAB_BUNDLE_VERSION"] = c.Bundle.Version
-
 	return &driver.Operation{
-		Action:       action,
-		Installation: c.Name,
-		Parameters:   c.Parameters,
-		Image:        ii.Image,
-		ImageType:    ii.ImageType,
-		Revision:     c.Revision,
-		Environment:  env,
-		Files:        files,
-		Out:          w,
+		Image:     ii.Image,
+		ImageType: ii.ImageType,
+		Input: driver.Input{
+			Installation: driver.InputInstallation{
+				Name:     c.Name,
+				Action:   action,
+				Revision: c.Revision,
+			},
+			Bundle:          *c.Bundle,
+			InvocationImage: ii,
+			Parameters:      c.Parameters,
+			Credentials:     creds,
+		},
+		Out: w,
 	}, nil
 }

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -1,7 +1,6 @@
 package action
 
 import (
-	"encoding/json"
 	"errors"
 	"os"
 	"strings"
@@ -106,20 +105,16 @@ func TestOpFromClaim(t *testing.T) {
 
 	is := assert.New(t)
 
-	is.Equal(c.Name, op.Installation)
-	is.Equal(c.Revision, op.Revision)
+	is.Equal(c.Name, op.Input.Installation.Name)
+	is.Equal(c.Revision, op.Input.Installation.Revision)
 	is.Equal(invocImage.Image, op.Image)
 	is.Equal(driver.ImageTypeDocker, op.ImageType)
-	is.Equal(op.Environment["SECRET_ONE"], "I'm a secret")
-	is.Equal(op.Environment["PARAM_TWO"], "twoval")
-	is.Equal(op.Environment["CNAB_P_PARAM_ONE"], "oneval")
-	is.Equal(op.Files["/secret/two"], "I'm also a secret")
-	is.Equal(op.Files["/param/three"], "threeval")
-	is.Contains(op.Files, "/cnab/app/image-map.json")
-	var imgMap map[string]bundle.Image
-	is.NoError(json.Unmarshal([]byte(op.Files["/cnab/app/image-map.json"]), &imgMap))
-	is.Equal(c.Bundle.Images, imgMap)
-	is.Len(op.Parameters, 3)
+	is.Equal(op.Input.Credentials["secret_one"], "I'm a secret")
+	is.Equal(op.Input.Credentials["secret_two"], "I'm also a secret")
+	is.Equal(op.Input.Parameters["param_one"], "oneval")
+	is.Equal(op.Input.Parameters["param_two"], "twoval")
+	is.Equal(op.Input.Parameters["param_three"], "threeval")
+	is.Equal(op.Input.Bundle, *c.Bundle)
 	is.Equal(os.Stdout, op.Out)
 }
 

--- a/pkg/driver/command_driver.go
+++ b/pkg/driver/command_driver.go
@@ -45,18 +45,6 @@ func (d *CommandDriver) exec(op *Operation) error {
 	// to pass that data on to the image it invokes. So we do some data
 	// duplication.
 
-	// Construct an environment for the subprocess by cloning our
-	// environment and adding in all the extra env vars.
-	pairs := os.Environ()
-	added := []string{}
-	for k, v := range op.Environment {
-		pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
-		added = append(added, k)
-	}
-	// DUFFLE_VARS is a list of variables we added to the env. This is to make
-	// it easier for shell script drivers to clone the env vars.
-	pairs = append(pairs, fmt.Sprintf("DUFFLE_VARS=%s", strings.Join(added, ",")))
-
 	data, err := json.Marshal(op)
 	if err != nil {
 		return err
@@ -67,7 +55,6 @@ func (d *CommandDriver) exec(op *Operation) error {
 	if err != nil {
 		return err
 	}
-	cmd.Env = pairs
 	cmd.Stdin = bytes.NewBuffer(data)
 	out, err := cmd.CombinedOutput()
 	fmt.Fprintln(op.Out, string(out))

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -4,7 +4,34 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/deislabs/duffle/pkg/bundle"
+	"github.com/deislabs/duffle/pkg/credentials"
 )
+
+// Input describes the input configuration available on stdin from within the invocation image
+type Input struct {
+	// Installation is the details of the installation
+	Installation InputInstallation `json:"installation"`
+	// InvocationImage is the details of the image that is being invoked
+	InvocationImage bundle.InvocationImage `json:"invocation_image"`
+	// Bundle is the entire contents of the bundle.json
+	Bundle bundle.Bundle `json:"bundle"`
+	// Parameters is the set of resolved parameters
+	Parameters map[string]interface{} `json:"parameters"`
+	// Credentials is the set of resolved credentials
+	Credentials credentials.Set `json:"credentials"`
+}
+
+// InputInstallation describes the name, action, revision for the installation
+type InputInstallation struct {
+	// Name is the name of the installation
+	Name string `json:"name"`
+	// Action is the action to be performed
+	Action string `json:"action"`
+	// Revision is the revision ID for this installation
+	Revision string `json:"revision"`
+}
 
 // ImageType constants provide some of the image types supported
 // TODO: I think we can remove all but Docker, since the rest are supported externally
@@ -28,24 +55,14 @@ func Lookup(name string) (Driver, error) {
 
 // Operation describes the data passed into the driver to run an operation
 type Operation struct {
-	// Installation is the name of this installation
-	Installation string `json:"installation_name"`
-	// The revision ID for this installation
-	Revision string `json:"revision"`
-	// Action is the action to be performed
-	Action string `json:"action"`
-	// Parameters are the parameters to be injected into the container
-	Parameters map[string]interface{} `json:"parameters"`
 	// Image is the invocation image
 	Image string `json:"image"`
 	// ImageType is the type of image.
 	ImageType string `json:"image_type"`
-	// Environment contains environment variables that should be injected into the invocation image
-	Environment map[string]string `json:"environment"`
-	// Files contains files that should be injected into the invocation image.
-	Files map[string]string `json:"files"`
 	// Output stream for log messages from the driver
 	Out io.Writer
+
+	Input Input `json:"input"`
 }
 
 // ResolvedCred is a credential that has been resolved and is ready for injection into the runtime.

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -33,10 +33,9 @@ func TestDebugDriver_Run(t *testing.T) {
 	is.NotNil(d)
 
 	op := &Operation{
-		Installation: "test",
-		Image:        "test:1.2.3",
-		ImageType:    "oci",
-		Out:          ioutil.Discard,
+		Image:     "test:1.2.3",
+		ImageType: "oci",
+		Out:       ioutil.Discard,
 	}
 	is.NoError(d.Run(op))
 }
@@ -62,12 +61,9 @@ func TestDockerDriver_Run(t *testing.T) {
 	is.NotNil(d)
 
 	op := &Operation{
-		Installation: "test",
-		Image:        "test:1.2.3",
-		ImageType:    "oci",
-		Environment:  map[string]string{},
-		Files:        map[string]string{},
-		Out:          ioutil.Discard,
+		Image:     "test:1.2.3",
+		ImageType: "oci",
+		Out:       ioutil.Discard,
 	}
 	is.NoError(d.Run(op))
 }


### PR DESCRIPTION
This is a rough implementation of a CNAB spec [proposal](https://github.com/deislabs/cnab-spec/issues/114) to change the process for passing configuration data into invocation images. Please excuse my ignorance of the golang libraries for interacting with docker. I believe that I made the minimal set of changes required to stream input to STDIN for the run tool when performing an action.

The changes here are not really meant to be merged, but more to serve as a living example of what the changes to a runtime would be as a result of the spec proposal.