### PR TITLE
Remove Docker socket from file mounts in driver

### DIFF
--- a/pkg/driver/docker_driver.go
+++ b/pkg/driver/docker_driver.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -127,13 +126,6 @@ func (d *DockerDriver) exec(op *Operation) error {
 		env = append(env, fmt.Sprintf("%s=%v", k, v))
 	}
 
-	mounts := []mount.Mount{
-		{
-			Type:   mount.TypeBind,
-			Source: "/var/run/docker.sock",
-			Target: "/var/run/docker.sock",
-		},
-	}
 	cfg := &container.Config{
 		Image:        op.Image,
 		Env:          env,
@@ -142,7 +134,7 @@ func (d *DockerDriver) exec(op *Operation) error {
 		AttachStdout: true,
 	}
 
-	hostCfg := &container.HostConfig{Mounts: mounts, AutoRemove: true}
+	hostCfg := &container.HostConfig{AutoRemove: true}
 
 	resp, err := cli.Client().ContainerCreate(ctx, cfg, hostCfg, nil, "")
 	switch {


### PR DESCRIPTION
closes #650
closes https://github.com/deislabs/cnab-spec/issues/108

This PR simply removes the Docker socket.
We had an initial discussion during last week's standup, but I'll re-start it here: with the current implementation, the bundles that deployed Docker Compose files to the same daemon no longer work in their current state.

Should there be a way to run the invocation image as a privileged container in Duffle?