### PR TITLE
Add Docker Driver configuration options

### DIFF
--- a/pkg/driver/docker_driver.go
+++ b/pkg/driver/docker_driver.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -127,13 +126,6 @@ func (d *DockerDriver) exec(op *Operation) error {
 		env = append(env, fmt.Sprintf("%s=%v", k, v))
 	}
 
-	mounts := []mount.Mount{
-		{
-			Type:   mount.TypeBind,
-			Source: "/var/run/docker.sock",
-			Target: "/var/run/docker.sock",
-		},
-	}
 	cfg := &container.Config{
 		Image:        op.Image,
 		Env:          env,
@@ -142,7 +134,7 @@ func (d *DockerDriver) exec(op *Operation) error {
 		AttachStdout: true,
 	}
 
-	hostCfg := &container.HostConfig{Mounts: mounts, AutoRemove: true}
+	hostCfg := &container.HostConfig{AutoRemove: true}
 
 	resp, err := cli.Client().ContainerCreate(ctx, cfg, hostCfg, nil, "")
 	switch {


### PR DESCRIPTION
Based on @radu-matei 's #651.

This adds support for additive container.Config / container.HostConfig options in the Docker Driver.
The motivation is that:
- docker-app now creates an invocation image that runs with a non-root user by default
- when we detect that we want to deploy on a local swarm cluster (e.g. the target docker context host is something like `unix:///var/run/docker.sock`, we want docker-app to detect that and customize the docker driver to actually bind mount the socket (which won't be done by default), and the invocation image with a user which has read/write access to it.

This is a pretty important feature for docker-app local usage with Docker Dekstop

cc @chris-crone 