### PR TITLE
fix: fix deserialization of duffle .* files

### DIFF
--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -3,12 +3,12 @@ package builder
 import (
 	"context"
 	"io"
-	"reflect"
 	"testing"
 
 	"github.com/deislabs/duffle/pkg/bundle"
 	"github.com/deislabs/duffle/pkg/duffle/manifest"
 	"github.com/deislabs/duffle/pkg/imagebuilder"
+	"github.com/stretchr/testify/assert"
 )
 
 // testImage represents a mock invocation image
@@ -68,6 +68,13 @@ func TestPrepareBuild(t *testing.T) {
 				URL:   "https://test.com",
 			},
 		},
+		Actions: map[string]bundle.Action{
+			"hello": {
+				Description: "says hello",
+				Stateless:   true,
+				Modifies:    false,
+			},
+		},
 	}
 
 	components := []imagebuilder.ImageBuilder{
@@ -92,7 +99,7 @@ func TestPrepareBuild(t *testing.T) {
 	expected := bundle.InvocationImage{}
 	expected.Image = "cnab:0.1.0"
 	expected.ImageType = "docker"
-	if !reflect.DeepEqual(b.InvocationImages[0], expected) {
-		t.Errorf("expected %v, got %v", expected, b.InvocationImages[0])
-	}
+
+	assert.Equal(t, expected, b.InvocationImages[0])
+	assert.Equal(t, "says hello", b.Actions["hello"].Description)
 }

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -66,7 +66,7 @@ type LocationRef struct {
 
 // BaseImage contains fields shared across image types
 type BaseImage struct {
-	ImageType string        `json:"imageType" mapstructure:"imageType"`
+	ImageType string        `json:"imageType,omitempty" mapstructure:"imageType"`
 	Image     string        `json:"image" mapstructure:"image"`
 	Digest    string        `json:"digest,omitempty" mapstructure:"digest"`
 	Size      uint64        `json:"size,omitempty" mapstructure:"size"`
@@ -82,14 +82,14 @@ type ImagePlatform struct {
 
 // Image describes a container image in the bundle
 type Image struct {
-	BaseImage
+	BaseImage   `mapstructure:",squash"`
 	Description string        `json:"description" mapstructure:"description"` //TODO: change? see where it's being used? change to description?
 	Refs        []LocationRef `json:"refs" mapstructure:"refs"`
 }
 
 // InvocationImage contains the image type and location for the installation of a bundle
 type InvocationImage struct {
-	BaseImage
+	BaseImage `mapstructure:",squash"`
 }
 
 // Location provides the location where a value should be written in
@@ -116,7 +116,9 @@ type Action struct {
 	// Modifies indicates whether this action modifies the release.
 	//
 	// If it is possible that an action modify a release, this must be set to true.
-	Modifies bool `json:"modifies" mapstructure:"modifies"`
+	Modifies    bool   `json:"modifies,omitempty" mapstructure:"modifies"`
+	Stateless   bool   `json:"stateless,omitempty" mapstructure:"stateless"`
+	Description string `json:"description,omitempty" mapstructure:"description"`
 }
 
 // ValuesOrDefaults returns parameter values or the default parameter values

--- a/pkg/duffle/manifest/manifest_test.go
+++ b/pkg/duffle/manifest/manifest_test.go
@@ -28,6 +28,7 @@ func TestGenerateName(t *testing.T) {
 }
 
 func TestLoad(t *testing.T) {
+	is := assert.New(t)
 	testcases := []string{"", "duffle.toml", "duffle.json", "duffle.yaml"}
 
 	for _, tc := range testcases {
@@ -42,52 +43,31 @@ func TestLoad(t *testing.T) {
 			}
 
 			wantName := "testbundle"
-			if m.Name != wantName {
-				t.Errorf("expected Name to be %q but got %q", wantName, m.Name)
-			}
-
-			if len(m.InvocationImages) != 1 {
-				t.Fatalf("expected 1 component but got %d", len(m.InvocationImages))
-			}
-
+			is.Equal(wantName, m.Name)
+			is.Len(m.InvocationImages, 1)
 			if _, ok := m.InvocationImages["cnab"]; !ok {
-				t.Errorf("expected a component named cnab but got %v", m.InvocationImages)
+				t.Fatalf("expected a component named cnab but got %v", m.InvocationImages)
 			}
 
-			if len(m.Parameters) != 1 {
-				t.Fatalf("expected 1 parameter but got %d", len(m.Parameters))
-			}
-
+			is.Len(m.Parameters, 1)
 			param, ok := m.Parameters["foo"]
-			if !ok {
-				t.Errorf("expected a parameter named foo but got %v", m.Parameters)
-			}
-
-			if param.DataType != "string" {
-				t.Errorf("expected foo parameter to have a type of string but got %v", param.DataType)
-			}
-
-			if len(m.Credentials) != 1 {
-				t.Fatalf("expected 1 credential but got %d", len(m.Credentials))
-			}
+			is.True(ok, "param should exist")
+			is.Equal("string", param.DataType)
+			is.Len(m.Credentials, 1)
 
 			cred, ok := m.Credentials["bar"]
-			if !ok {
-				t.Errorf("expected a credential named bar but got %v", m.Credentials)
-			}
-
-			if cred.Path != "/tmp" {
-				t.Errorf("expected foo credential to have a path of /tmp but got %v", cred.Path)
-			}
-
-			if len(m.Maintainers) != 1 {
-				t.Fatalf("expected 1 maintainer but got %d", len(m.Maintainers))
-			}
+			is.True(ok, "expected credential")
+			is.Equal("/tmp", cred.Path)
+			is.Len(m.Maintainers, 1)
 
 			maintainer := m.Maintainers[0]
-			if maintainer.Name != "sally" {
-				t.Errorf("expected maintainer to be sally but got %v", maintainer.Name)
-			}
+			is.Equal("sally", maintainer.Name)
+
+			is.Len(m.Images, 1)
+			is.Equal("test:latest", m.Images["test"].Image)
+
+			is.Len(m.Actions, 1)
+			is.Equal("says hello", m.Actions["hello"].Description)
 		})
 	}
 }

--- a/pkg/duffle/manifest/testdata/duffle.json
+++ b/pkg/duffle/manifest/testdata/duffle.json
@@ -23,5 +23,16 @@
     {
       "name": "sally"
     }
-  ]
+  ],
+  "actions": {
+    "hello": {
+      "description": "says hello",
+      "stateless": true
+    }
+  },
+  "images": {
+    "test": {
+      "image": "test:latest"
+    }
+  }
 }

--- a/pkg/duffle/manifest/testdata/duffle.toml
+++ b/pkg/duffle/manifest/testdata/duffle.toml
@@ -12,3 +12,12 @@ name = "testbundle"
 
 [[maintainers]]
   name = "sally"
+
+[actions]
+    [actions.hello]
+        description= "says hello"
+        stateless = true
+
+[images]
+    [images.test]
+        image = "test:latest"

--- a/pkg/duffle/manifest/testdata/duffle.yaml
+++ b/pkg/duffle/manifest/testdata/duffle.yaml
@@ -14,3 +14,10 @@ credentials:
 maintainers:
 - name: sally
 
+actions:
+    hello:
+      description: "says hello"
+      stateless: true
+images:
+    test:
+      image: "test:latest"


### PR DESCRIPTION
Some duffle files were not unmarshalling correctly. In addition, there were several missing attributes in the bundle and manifest descriptions.

Cleaned up some tests along the way.

Thnks to @sbawaska  for pointing out the critical change

Closes #658