### PR TITLE
Update bundle model

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -116,7 +116,7 @@ type Action struct {
 	// Modifies indicates whether this action modifies the release.
 	//
 	// If it is possible that an action modify a release, this must be set to true.
-	Modifies bool `json:"modifies" mapstructure:"modifies"`
+	Modifies bool `json:"modifies,omitempty" mapstructure:"modifies"`
 	// Stateless indicates that the action is purely informational, that credentials are not required, and that the runtime should not keep track of its invocation
 	Stateless bool `json:"stateless,omitempty" mapstructure:"stateless"`
 	// Description describes the action as a user-readable string

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -97,8 +97,8 @@ type InvocationImage struct {
 //
 // A location may be either a file (by path) or an environment variable.
 type Location struct {
-	Path                string `json:"path" mapstructure:"path"`
-	EnvironmentVariable string `json:"env" mapstructure:"env"`
+	Path                string `json:"path,omitempty" mapstructure:"path"`
+	EnvironmentVariable string `json:"env,omitempty" mapstructure:"env"`
 }
 
 // Maintainer describes a code maintainer of a bundle

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -67,12 +67,12 @@ type LocationRef struct {
 
 // BaseImage contains fields shared across image types
 type BaseImage struct {
-	ImageType string        `json:"imageType" mapstructure:"imageType"`
-	Image     string        `json:"image" mapstructure:"image"`
-	Digest    string        `json:"digest,omitempty" mapstructure:"digest"`
-	Size      uint64        `json:"size,omitempty" mapstructure:"size"`
-	Platform  ImagePlatform `json:"platform,omitempty" mapstructure:"platform"`
-	MediaType string        `json:"mediaType,omitempty" mapstructure:"mediaType"`
+	ImageType string         `json:"imageType" mapstructure:"imageType"`
+	Image     string         `json:"image" mapstructure:"image"`
+	Digest    string         `json:"digest,omitempty" mapstructure:"digest"`
+	Size      uint64         `json:"size,omitempty" mapstructure:"size"`
+	Platform  *ImagePlatform `json:"platform,omitempty" mapstructure:"platform"`
+	MediaType string         `json:"mediaType,omitempty" mapstructure:"mediaType"`
 }
 
 // ImagePlatform indicates what type of platform an image is built for

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -106,9 +106,9 @@ type Maintainer struct {
 	// Name is a user name or organization name
 	Name string `json:"name" mapstructure:"name"`
 	// Email is an optional email address to contact the named maintainer
-	Email string `json:"email" mapstructure:"email"`
+	Email string `json:"email,omitempty" mapstructure:"email"`
 	// Url is an optional URL to an address for the named maintainer
-	URL string `json:"url" mapstructure:"url"`
+	URL string `json:"url,omitempty" mapstructure:"url"`
 }
 
 // Action describes a custom (non-core) action.

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -84,8 +84,7 @@ type ImagePlatform struct {
 // Image describes a container image in the bundle
 type Image struct {
 	BaseImage   `mapstructure:",squash"`
-	Description string        `json:"description" mapstructure:"description"` //TODO: change? see where it's being used? change to description?
-	Refs        []LocationRef `json:"refs" mapstructure:"refs"`
+	Description string `json:"description" mapstructure:"description"` //TODO: change? see where it's being used? change to description?
 }
 
 // InvocationImage contains the image type and location for the installation of a bundle

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -16,11 +16,11 @@ type Bundle struct {
 	Name             string                         `json:"name" mapstructure:"name"`
 	Version          string                         `json:"version" mapstructure:"version"`
 	Description      string                         `json:"description" mapstructure:"description"`
-	Keywords         []string                       `json:"keywords,omitempty" mapstructure:"keywords,omitempty"`
-	Maintainers      []Maintainer                   `json:"maintainers,omitempty" mapstructure:"maintainers,omitempty"`
+	Keywords         []string                       `json:"keywords,omitempty" mapstructure:"keywords"`
+	Maintainers      []Maintainer                   `json:"maintainers,omitempty" mapstructure:"maintainers"`
 	InvocationImages []InvocationImage              `json:"invocationImages" mapstructure:"invocationImages"`
 	Images           map[string]Image               `json:"images" mapstructure:"images"`
-	Actions          map[string]Action              `json:"actions,omitempty" mapstructure:"actions,omitempty"`
+	Actions          map[string]Action              `json:"actions,omitempty" mapstructure:"actions"`
 	Parameters       map[string]ParameterDefinition `json:"parameters" mapstructure:"parameters"`
 	Credentials      map[string]Location            `json:"credentials" mapstructure:"credentials"`
 }
@@ -120,7 +120,7 @@ type Action struct {
 	// Stateless indicates that the action is purely informational, that credentials are not required, and that the runtime should not keep track of its invocation
 	Stateless bool `json:"stateless,omitempty" mapstructure:"stateless"`
 	// Description describes the action as a user-readable string
-	Description string `json:"description,omitempty" mapstructure:"description,omitempty"`
+	Description string `json:"description,omitempty" mapstructure:"description"`
 }
 
 // ValuesOrDefaults returns parameter values or the default parameter values

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -52,9 +52,6 @@ func TestReadImageProperties(t *testing.T) {
 	if image1.Image != "urn:image1uri" {
 		t.Errorf("Expected Image 'urn:image1uri', got '%s'", image1.Image)
 	}
-	if len(image1.Refs) != 1 {
-		t.Errorf("Expected 1 ref, got %d", len(image1.Refs))
-	}
 }
 
 func TestReadCredentialProperties(t *testing.T) {

--- a/pkg/bundle/parameters.go
+++ b/pkg/bundle/parameters.go
@@ -12,7 +12,7 @@ type ParameterDefinition struct {
 	DataType      string             `json:"type" mapstructure:"type"`
 	DefaultValue  interface{}        `json:"defaultValue,omitempty" mapstructure:"defaultValue"`
 	AllowedValues []interface{}      `json:"allowedValues,omitempty" mapstructure:"allowedValues"`
-	Required      bool               `json:"required" mapstructure:"required"`
+	Required      bool               `json:"required,omitempty" mapstructure:"required"`
 	MinValue      *int               `json:"minValue,omitempty" mapstructure:"minValue"`
 	MaxValue      *int               `json:"maxValue,omitempty" mapstructure:"maxValue"`
 	MinLength     *int               `json:"minLength,omitempty" mapstructure:"minLength"`

--- a/pkg/bundle/parameters.go
+++ b/pkg/bundle/parameters.go
@@ -9,17 +9,17 @@ import (
 
 // ParameterDefinition defines a single parameter for a CNAB bundle
 type ParameterDefinition struct {
-	DataType      string            `json:"type" mapstructure:"type"`
-	DefaultValue  interface{}       `json:"defaultValue,omitempty" mapstructure:"defaultValue,omitempty"`
-	AllowedValues []interface{}     `json:"allowedValues,omitempty" mapstructure:"allowedValues,omitempty"`
-	Required      bool              `json:"required" mapstructure:"required"`
-	MinValue      *int              `json:"minValue,omitempty" mapstructure:"minValue,omitempty"`
-	MaxValue      *int              `json:"maxValue,omitempty" mapstructure:"maxValue,omitempty"`
-	MinLength     *int              `json:"minLength,omitempty" mapstructure:"minLength,omitempty"`
-	MaxLength     *int              `json:"maxLength,omitempty" mapstructure:"maxLength,omitempty"`
-	Metadata      ParameterMetadata `json:"metadata,omitempty" mapstructure:"metadata,omitempty"`
-	Destination   *Location         `json:"destination,omitempty" mapstructure:"destination,omitempty"`
-	ApplyTo       []string          `json:"apply-to,omitempty" mapstructure:"apply-to,omitempty"`
+	DataType      string             `json:"type" mapstructure:"type"`
+	DefaultValue  interface{}        `json:"defaultValue,omitempty" mapstructure:"defaultValue,omitempty"`
+	AllowedValues []interface{}      `json:"allowedValues,omitempty" mapstructure:"allowedValues,omitempty"`
+	Required      bool               `json:"required" mapstructure:"required"`
+	MinValue      *int               `json:"minValue,omitempty" mapstructure:"minValue,omitempty"`
+	MaxValue      *int               `json:"maxValue,omitempty" mapstructure:"maxValue,omitempty"`
+	MinLength     *int               `json:"minLength,omitempty" mapstructure:"minLength,omitempty"`
+	MaxLength     *int               `json:"maxLength,omitempty" mapstructure:"maxLength,omitempty"`
+	Metadata      *ParameterMetadata `json:"metadata,omitempty" mapstructure:"metadata,omitempty"`
+	Destination   *Location          `json:"destination,omitempty" mapstructure:"destination,omitempty"`
+	ApplyTo       []string           `json:"apply-to,omitempty" mapstructure:"apply-to,omitempty"`
 }
 
 // ParameterMetadata contains metadata for a parameter definition.

--- a/pkg/bundle/parameters.go
+++ b/pkg/bundle/parameters.go
@@ -10,21 +10,21 @@ import (
 // ParameterDefinition defines a single parameter for a CNAB bundle
 type ParameterDefinition struct {
 	DataType      string             `json:"type" mapstructure:"type"`
-	DefaultValue  interface{}        `json:"defaultValue,omitempty" mapstructure:"defaultValue,omitempty"`
-	AllowedValues []interface{}      `json:"allowedValues,omitempty" mapstructure:"allowedValues,omitempty"`
+	DefaultValue  interface{}        `json:"defaultValue,omitempty" mapstructure:"defaultValue"`
+	AllowedValues []interface{}      `json:"allowedValues,omitempty" mapstructure:"allowedValues"`
 	Required      bool               `json:"required" mapstructure:"required"`
-	MinValue      *int               `json:"minValue,omitempty" mapstructure:"minValue,omitempty"`
-	MaxValue      *int               `json:"maxValue,omitempty" mapstructure:"maxValue,omitempty"`
-	MinLength     *int               `json:"minLength,omitempty" mapstructure:"minLength,omitempty"`
-	MaxLength     *int               `json:"maxLength,omitempty" mapstructure:"maxLength,omitempty"`
-	Metadata      *ParameterMetadata `json:"metadata,omitempty" mapstructure:"metadata,omitempty"`
-	Destination   *Location          `json:"destination,omitempty" mapstructure:"destination,omitempty"`
+	MinValue      *int               `json:"minValue,omitempty" mapstructure:"minValue"`
+	MaxValue      *int               `json:"maxValue,omitempty" mapstructure:"maxValue"`
+	MinLength     *int               `json:"minLength,omitempty" mapstructure:"minLength"`
+	MaxLength     *int               `json:"maxLength,omitempty" mapstructure:"maxLength"`
+	Metadata      *ParameterMetadata `json:"metadata,omitempty" mapstructure:"metadata"`
+	Destination   *Location          `json:"destination,omitemtpty" mapstructure:"destination"`
 	ApplyTo       []string           `json:"apply-to,omitempty" mapstructure:"apply-to,omitempty"`
 }
 
 // ParameterMetadata contains metadata for a parameter definition.
 type ParameterMetadata struct {
-	Description string `json:"description,omitempty" mapstructure:"description,omitempty"`
+	Description string `json:"description,omitempty" mapstructure:"description"`
 }
 
 // ValidateParameterValue checks whether a value is valid as the value of

--- a/pkg/duffle/manifest/manifest.go
+++ b/pkg/duffle/manifest/manifest.go
@@ -13,14 +13,14 @@ import (
 type Manifest struct {
 	Name             string                                `json:"name" mapstructure:"name"`
 	Version          string                                `json:"version" mapstructure:"version"`
-	Description      string                                `json:"description,omitempty" mapstructure:"description,omitempty"`
-	Keywords         []string                              `json:"keywords,omitempty" mapstructure:"keywords,omitempty"`
-	Maintainers      []bundle.Maintainer                   `json:"maintainers,omitempty" mapstructure:"maintainers,omitempty"`
-	InvocationImages map[string]*InvocationImage           `json:"invocationImages,omitempty" mapstructure:"invocationImages,omitempty"`
-	Images           map[string]bundle.Image               `json:"images,omitempty" mapstructure:"images,omitempty"`
-	Actions          map[string]bundle.Action              `json:"actions,omitempty" mapstructure:"actions,omitempty"`
-	Parameters       map[string]bundle.ParameterDefinition `json:"parameters,omitempty" mapstructure:"parameters,omitempty"`
-	Credentials      map[string]bundle.Location            `json:"credentials,omitempty" mapstructure:"credentials,omitempty"`
+	Description      string                                `json:"description,omitempty" mapstructure:"description"`
+	Keywords         []string                              `json:"keywords,omitempty" mapstructure:"keywords"`
+	Maintainers      []bundle.Maintainer                   `json:"maintainers,omitempty" mapstructure:"maintainers"`
+	InvocationImages map[string]*InvocationImage           `json:"invocationImages,omitempty" mapstructure:"invocationImages"`
+	Images           map[string]bundle.Image               `json:"images,omitempty" mapstructure:"images"`
+	Actions          map[string]bundle.Action              `json:"actions,omitempty" mapstructure:"actions"`
+	Parameters       map[string]bundle.ParameterDefinition `json:"parameters,omitempty" mapstructure:"parameters"`
+	Credentials      map[string]bundle.Location            `json:"credentials,omitempty" mapstructure:"credentials"`
 }
 
 // InvocationImage represents an invocation image component of a CNAB bundle


### PR DESCRIPTION
* In the specifications, platform is marked as OPTIONAL, and the JSON serialization is well tagged as omitempty. However a struct by copy is never empty, so the serialization always prints an empty map:
```
"images": {
	"api": {
		"imageType": "docker",
		"image": "python:3.6",
		"platform": {},
		"description": "python:3.6"
	},
...
```
To fix it I added a pointer to platform.

* Same fix for `parameter.Metadata`
* Removed `Image.Refs` as it was removed from the specifications https://github.com/deislabs/cnab-spec/pull/123