### PR TITLE
Add "apply-to" field to parameter definition

### DIFF
--- a/pkg/bundle/parameters.go
+++ b/pkg/bundle/parameters.go
@@ -18,7 +18,8 @@ type ParameterDefinition struct {
 	MinLength     *int              `json:"minLength,omitempty" mapstructure:"minLength,omitempty"`
 	MaxLength     *int              `json:"maxLength,omitempty" mapstructure:"maxLength,omitempty"`
 	Metadata      ParameterMetadata `json:"metadata,omitempty" mapstructure:"metadata,omitempty"`
-	Destination   *Location         `json:"destination,omitemtpty" mapstructure:"destination,omitempty"`
+	Destination   *Location         `json:"destination,omitempty" mapstructure:"destination,omitempty"`
+	ApplyTo       []string          `json:"apply-to,omitempty" mapstructure:"apply-to,omitempty"`
 }
 
 // ParameterMetadata contains metadata for a parameter definition.

--- a/pkg/bundle/parameters_test.go
+++ b/pkg/bundle/parameters_test.go
@@ -39,6 +39,9 @@ func TestCanReadParameterDefinition(t *testing.T) {
 	minLength := 300
 	maxLength := 400
 	description := "some description"
+	action0 := "action0"
+	action1 := "action1"
+
 	json := fmt.Sprintf(`{
 		"parameters": {
 			"test": {
@@ -51,12 +54,14 @@ func TestCanReadParameterDefinition(t *testing.T) {
 				"maxLength": %d,
 				"metadata": {
 					"description": "%s"
-				}
+				},
+				"apply-to": [ "%s", "%s" ]
 			}
 		}
 	}`,
 		dataType, defaultValue, allowedValues0, allowedValues1,
-		minValue, maxValue, minLength, maxLength, description)
+		minValue, maxValue, minLength, maxLength, description,
+		action0, action1)
 
 	definitions, err := Unmarshal([]byte(json))
 	if err != nil {
@@ -93,6 +98,15 @@ func TestCanReadParameterDefinition(t *testing.T) {
 	}
 	if p.Metadata.Description != description {
 		t.Errorf("Expected description '%s' but got '%s'", description, p.Metadata.Description)
+	}
+	if len(p.ApplyTo) != 2 {
+		t.Errorf("Expected 2 apply-to actions but got %d", len(p.ApplyTo))
+	}
+	if p.ApplyTo[0] != action0 {
+		t.Errorf("Expected action '%s' but got '%s'", action0, p.ApplyTo[0])
+	}
+	if p.ApplyTo[1] != action1 {
+		t.Errorf("Expected action '%s' but got '%s'", action1, p.ApplyTo[1])
 	}
 }
 


### PR DESCRIPTION
Also add a check that an action is in the parameter's apply-to list.

Specifications here: https://github.com/deislabs/cnab-spec/pull/103/files