### PR TITLE
[feat-633-bundle-actions-cmd] Add bundle actions command

### DIFF
--- a/cmd/duffle/bundle.go
+++ b/cmd/duffle/bundle.go
@@ -23,6 +23,7 @@ func newBundleCmd(w io.Writer) *cobra.Command {
 		newBundleSignCmd(w),
 		newBundleVerifyCmd(w),
 		newBundleRemoveCmd(w),
+		newBundleActionsCmd(w),
 	)
 	return cmd
 }

--- a/cmd/duffle/bundle_actions.go
+++ b/cmd/duffle/bundle_actions.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/gosuri/uitable"
+	"github.com/spf13/cobra"
+)
+
+const bundleActionsDesc = ` Lists all actions available in a bundle`
+
+type bundleActionsCmd struct {
+	out        io.Writer
+	bundleFile string
+	insecure   bool
+}
+
+func newBundleActionsCmd(w io.Writer) *cobra.Command {
+	a := &bundleActionsCmd{out: w}
+
+	cmd := &cobra.Command{
+		Use:   "actions BUNDLE",
+		Short: bundleActionsDesc,
+		Long:  bundleActionsDesc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			bundle, err := bundleFileOrArg1(args, a.bundleFile)
+			if err != nil {
+				return err
+			}
+			return a.run(bundle)
+		},
+	}
+
+	cmd.Flags().StringVarP(&a.bundleFile, "file", "f", "", "path to the bundle file to show actions for")
+	cmd.Flags().BoolVarP(&a.insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
+
+	return cmd
+}
+
+func (a *bundleActionsCmd) run(bundleFile string) error {
+
+	// Verify that file exists
+	if fi, err := os.Stat(bundleFile); err != nil {
+		return fmt.Errorf("cannot find bundle file to sign: %v", err)
+	} else if fi.IsDir() {
+		return errors.New("cannot sign a directory")
+	}
+
+	bun, err := loadBundle(bundleFile, a.insecure)
+	if err != nil {
+		return err
+	}
+
+	table := uitable.New()
+	table.MaxColWidth = 100
+	table.Wrap = true
+
+	table.AddRow("ACTION", "STATELESS", "MODIFIES", "DESCRIPTION")
+	for name, act := range bun.Actions {
+		table.AddRow(name, act.Stateless, act.Modifies, act.Description)
+	}
+
+	fmt.Fprintln(a.out, table)
+
+	return nil
+}

--- a/cmd/duffle/bundle_actions_test.go
+++ b/cmd/duffle/bundle_actions_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestBundleActions(t *testing.T) {
+	out := bytes.NewBuffer(nil)
+	cmd := &bundleActionsCmd{
+		out:          out,
+		bundleIsFile: true,
+		bundle:       "./testdata/testbundle/actions-test-bundle.json",
+		insecure:     true,
+	}
+
+	if err := cmd.run(); err != nil {
+		t.Fatal(err)
+	}
+
+	result := out.String()
+
+	newLines := strings.Count(result, "\n")
+
+	// the bundle contains 3 actions, plus the table header
+	// so the output should have 4 lines
+	if newLines != 4 {
+		t.Errorf("Expected output to have 4 lines. It had %v", newLines)
+	}
+
+	if !strings.Contains(result, "dry-run") {
+		t.Errorf("Expected actions to contain %s but did not", "dry-run")
+	}
+	if !strings.Contains(result, "migrate") {
+		t.Errorf("Expected actions to contain %s but did not", "migrate")
+	}
+
+	if !strings.Contains(result, "status") {
+		t.Errorf("Expected actions to contain %s but did not", "status")
+	}
+}

--- a/cmd/duffle/testdata/testbundle/actions-test-bundle.json
+++ b/cmd/duffle/testdata/testbundle/actions-test-bundle.json
@@ -1,0 +1,17 @@
+{
+    "actions": {
+        "dry-run": {
+            "description": "prints what install would do with the given parameters values",
+            "modifies": false,
+            "stateless": true
+        },
+        "migrate": {
+            "description": "migration action",
+            "modifies": false
+        },
+        "status": {
+            "description": "retrieves the status of an installation",
+            "modifies": false
+        }
+    }
+}


### PR DESCRIPTION
close #633 

This PR adds a `duffle bundle actions` command that reads all actions from a bundle and displays them.

To test this, the following bundle file can be used:

```json
{
  "actions": {
    "dry-run": {
      "description": "prints what install would do with the given parameters values",
      "modifies": false,
      "stateless": true
    },
    "migrate": {
      "description": "migration action",
      "modifies": false
    },
    "status": {
      "description": "retrieves the status of an installation",
      "modifies": false
    }
  },
  "credentials": null,
  "description": "A short description of your bundle",
  "images": null,
  "invocationImages": [
    {
      "image": "padme/awesome-bundle-cnab:acff9ea424b7735b7cd6c342b7a6073f35337658",
      "imageType": "docker",
      "platform": {}
    }
  ],
  "keywords": [
    "cnab"
  ],
  "maintainers": [
    {
      "email": "padme@admidala.dev",
      "name": "Padme Amidala",
      "url": ""
    }
  ],
  "name": "awesome-bundle",
  "parameters": null,
  "version": "0.1.0"
}
```
Alternatively, the bundle can be build, and/or signed using `duffle build`.


```
$ duffle bundle actions -f bundle.json --insecure
ACTION 	STATELESS	MODIFIES	DESCRIPTION                                                  
migrate	false    	false   	migration action                                             
status 	false    	false   	retrieves the status of an installation                      
dry-run	true     	false   	prints what install would do with the given parameters values
```

cc @itowlson -- do you need this command to output JSON / other formats for the VS Code extension?