### PR TITLE
Configure container streams

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -80,7 +80,7 @@ type DebugDriver struct {
 	config map[string]string
 }
 
-// Run executes the operation on the Debug  driver
+// Run executes the operation on the Debug driver
 func (d *DebugDriver) Run(op *Operation) error {
 	data, err := json.MarshalIndent(op, "", "  ")
 	if err != nil {


### PR DESCRIPTION
Add output and error container streams configuration on Docker Driver, different from the Operation.Out, which is there to configure the driver logs.

Signed-off-by: Silvin Lubecki <silvin.lubecki@docker.com>