### PR TITLE
Re-enable azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,31 @@
+# Go
+# Build your Go application.
+# Add steps that test, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/vsts/pipelines/languages/go
+
+pool:
+  vmImage: 'Ubuntu 16.04'
+
+variables:
+  GOBIN:  '$(GOPATH)/bin' # Go binaries path
+  GOROOT: '/usr/local/go1.11' # Go installation path
+  GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
+  modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)' # Path to the module's code
+
+steps:
+- script: |
+    mkdir -p '$(GOBIN)'
+    mkdir -p '$(GOPATH)/pkg'
+    mkdir -p '$(modulePath)'
+    shopt -s extglob
+    mv !(gopath) '$(modulePath)'
+    echo '##vso[task.prependpath]$(GOBIN)'
+    echo '##vso[task.prependpath]$(GOROOT)/bin'
+  displayName: 'Set up the Go workspace'
+
+- script: |
+    go version
+    go get -v -t -d ./...
+    make bootstrap build test lint
+  workingDirectory: '$(modulePath)'
+  displayName: 'Get dependencies, build, test'


### PR DESCRIPTION
Having trouble with our brigade cluster after the azure subscription migration so back to pipelines.

It's worth noting that I am restoring the last used azure pipeline configuration file. Since this was used, we've made changes that are only in the brigade.js file, mostly related to publishing. The changes aren't easy makefile targets to just add to the pipeline file as well (note to future self, life is easier if logic is in the makefile, not the CI specific config file). So if we want to do a release, we'll need to move over more logic from the brigade file.

But this will give us a safety net again until brigade is back up and running.