### PR TITLE
Add a `Merge` method to `credentials.Set`

### DIFF
--- a/pkg/credentials/credentialset.go
+++ b/pkg/credentials/credentialset.go
@@ -41,6 +41,20 @@ func (s Set) Expand(b *bundle.Bundle, stateless bool) (env, files map[string]str
 	return
 }
 
+// Merge merges a second Set into the base.
+//
+// Duplicate credential names are not allow and will result in an
+// error, this is the case even if the values are identical.
+func (s Set) Merge(s2 Set) error {
+	for k, v := range s2 {
+		if _, ok := s[k]; ok {
+			return fmt.Errorf("ambiguous credential resolution: %q is already present in base credential sets, cannot merge", k)
+		}
+		s[k] = v
+	}
+	return nil
+}
+
 // CredentialSet represents a collection of credentials
 type CredentialSet struct {
 	// Name is the name of the credentialset.

--- a/pkg/credentials/credentialset_test.go
+++ b/pkg/credentials/credentialset_test.go
@@ -86,6 +86,30 @@ func TestCredentialSet_Expand(t *testing.T) {
 	}
 }
 
+func TestCredentialSet_Merge(t *testing.T) {
+	cs := Set{
+		"first":  "first",
+		"second": "second",
+		"third":  "third",
+	}
+
+	is := assert.New(t)
+
+	err := cs.Merge(Set{})
+	is.NoError(err)
+	is.Len(cs, 3)
+	is.NotContains(cs, "fourth")
+
+	err = cs.Merge(Set{"fourth": "fourth"})
+	is.NoError(err)
+	is.Len(cs, 4)
+	is.Contains(cs, "fourth")
+
+	err = cs.Merge(Set{"second": "bis"})
+	is.EqualError(err, `ambiguous credential resolution: "second" is already present in base credential sets, cannot merge`)
+
+}
+
 func TestCredentialSetMissingCred(t *testing.T) {
 	b := &bundle.Bundle{
 		Name: "knapsack",


### PR DESCRIPTION
This will merge (union) all keys in a second `Set` into the given one.
Duplicates are not allowed and result in an error.

Signed-off-by: Ian Campbell <ijc@docker.com>

I also debated adding:
```
func (c *CredentialSet) ResolveAndMerge(s Set) (Set, error) {
```
Which would resolve `c` and then `s.Merge()` the values into `s`. WDYT?