### PR TITLE
Rename notStateless constant to stateful

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -13,8 +13,8 @@ import (
 	"github.com/deislabs/duffle/pkg/driver"
 )
 
-// notStateless is there just to make callers of opFromClaims more readable
-const notStateless = false
+// stateful is there just to make callers of opFromClaims more readable
+const stateful = false
 
 // Action describes one of the primary actions that can be executed in CNAB.
 //

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -99,7 +99,7 @@ func TestOpFromClaim(t *testing.T) {
 	}
 	invocImage := c.Bundle.InvocationImages[0]
 
-	op, err := opFromClaim(claim.ActionInstall, notStateless, c, invocImage, mockSet, os.Stdout)
+	op, err := opFromClaim(claim.ActionInstall, stateful, c, invocImage, mockSet, os.Stdout)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestOpFromClaim_UndefinedParams(t *testing.T) {
 	}
 	invocImage := c.Bundle.InvocationImages[0]
 
-	_, err := opFromClaim(claim.ActionInstall, notStateless, c, invocImage, mockSet, os.Stdout)
+	_, err := opFromClaim(claim.ActionInstall, stateful, c, invocImage, mockSet, os.Stdout)
 	assert.Error(t, err)
 }
 
@@ -163,12 +163,12 @@ func TestOpFromClaim_MissingRequiredParameter(t *testing.T) {
 	invocImage := c.Bundle.InvocationImages[0]
 
 	// missing required parameter fails
-	_, err := opFromClaim(claim.ActionInstall, notStateless, c, invocImage, mockSet, os.Stdout)
+	_, err := opFromClaim(claim.ActionInstall, stateful, c, invocImage, mockSet, os.Stdout)
 	assert.EqualError(t, err, `missing required parameter "param_one" for action "install"`)
 
 	// fill the missing parameter
 	c.Parameters["param_one"] = "oneval"
-	_, err = opFromClaim(claim.ActionInstall, notStateless, c, invocImage, mockSet, os.Stdout)
+	_, err = opFromClaim(claim.ActionInstall, stateful, c, invocImage, mockSet, os.Stdout)
 	assert.Nil(t, err)
 }
 
@@ -195,15 +195,15 @@ func TestOpFromClaim_MissingRequiredParamSpecificToAction(t *testing.T) {
 	invocImage := c.Bundle.InvocationImages[0]
 
 	// calling install action without the test required parameter for test action is ok
-	_, err := opFromClaim(claim.ActionInstall, notStateless, c, invocImage, mockSet, os.Stdout)
+	_, err := opFromClaim(claim.ActionInstall, stateful, c, invocImage, mockSet, os.Stdout)
 	assert.Nil(t, err)
 
 	// test action needs the required parameter
-	_, err = opFromClaim("test", notStateless, c, invocImage, mockSet, os.Stdout)
+	_, err = opFromClaim("test", stateful, c, invocImage, mockSet, os.Stdout)
 	assert.EqualError(t, err, `missing required parameter "param_test" for action "test"`)
 
 	c.Parameters["param_test"] = "only for test action"
-	_, err = opFromClaim("test", notStateless, c, invocImage, mockSet, os.Stdout)
+	_, err = opFromClaim("test", stateful, c, invocImage, mockSet, os.Stdout)
 	assert.Nil(t, err)
 }
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -20,7 +20,7 @@ func (i *Install) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error 
 		return err
 	}
 
-	op, err := opFromClaim(claim.ActionInstall, notStateless, c, invocImage, creds, w)
+	op, err := opFromClaim(claim.ActionInstall, stateful, c, invocImage, creds, w)
 	if err != nil {
 		return err
 	}

--- a/pkg/action/status.go
+++ b/pkg/action/status.go
@@ -20,7 +20,7 @@ func (i *Status) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error {
 		return err
 	}
 
-	op, err := opFromClaim(claim.ActionStatus, notStateless, c, invocImage, creds, w)
+	op, err := opFromClaim(claim.ActionStatus, stateful, c, invocImage, creds, w)
 	if err != nil {
 		return err
 	}

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -20,7 +20,7 @@ func (u *Uninstall) Run(c *claim.Claim, creds credentials.Set, w io.Writer) erro
 		return err
 	}
 
-	op, err := opFromClaim(claim.ActionUninstall, notStateless, c, invocImage, creds, w)
+	op, err := opFromClaim(claim.ActionUninstall, stateful, c, invocImage, creds, w)
 	if err != nil {
 		return err
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -20,7 +20,7 @@ func (u *Upgrade) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error 
 		return err
 	}
 
-	op, err := opFromClaim(claim.ActionUpgrade, notStateless, c, invocImage, creds, w)
+	op, err := opFromClaim(claim.ActionUpgrade, stateful, c, invocImage, creds, w)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Negation in names should be avoided.

Signed-off-by: Silvin Lubecki <silvin.lubecki@docker.com>