### PR TITLE
Update action.Action interface

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -26,7 +26,7 @@ const stateful = false
 // - status
 type Action interface {
 	// Run an action, and record the status in the given claim
-	Run(*claim.Claim, credentials.Set) error
+	Run(*claim.Claim, credentials.Set, io.Writer) error
 }
 
 func selectInvocationImage(d driver.Driver, c *claim.Claim) (bundle.InvocationImage, error) {

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// makes sure Install implements Action interface
+var _ Action = &Install{}
+
 func TestInstall_Run(t *testing.T) {
 	out := ioutil.Discard
 

--- a/pkg/action/run_custom_test.go
+++ b/pkg/action/run_custom_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// makes sure RunCustom implements Action interface
+var _ Action = &RunCustom{}
+
 func TestRunCustom(t *testing.T) {
 	out := ioutil.Discard
 	is := assert.New(t)

--- a/pkg/action/status_test.go
+++ b/pkg/action/status_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// makes sure Status implements Action interface
+var _ Action = &Status{}
+
 func TestStatus_Run(t *testing.T) {
 	out := ioutil.Discard
 

--- a/pkg/action/uninstall_test.go
+++ b/pkg/action/uninstall_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// makes sure Uninstall implements Action interface
+var _ Action = &Uninstall{}
+
 func TestUninstall_Run(t *testing.T) {
 	out := ioutil.Discard
 

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// makes sure Upgrade implements Action interface
+var _ Action = &Upgrade{}
+
 func TestUpgrade_Run(t *testing.T) {
 	out := ioutil.Discard
 


### PR DESCRIPTION
All the action implementations added a 3rd argument `io.Writer`, but this change was never reflected to the actual interface `action.Action`.
I also added static guards to check the actions implements the interface.

Signed-off-by: Silvin Lubecki <silvin.lubecki@docker.com>