### PR TITLE
Fix linting on master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ lint:
 HAS_DEP          := $(shell $(CHECK) dep)
 HAS_GOLANGCI     := $(shell $(CHECK) golangci-lint)
 HAS_GOIMPORTS    := $(shell $(CHECK) goimports)
+GOLANGCI_VERSION := v1.16.0
 
 .PHONY: build-drivers
 build-drivers:
@@ -88,7 +89,7 @@ ifndef HAS_DEP
 	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 endif
 ifndef HAS_GOLANGCI
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_VERSION)
 endif
 ifndef HAS_GOIMPORTS
 	go get -u golang.org/x/tools/cmd/goimports
@@ -98,4 +99,3 @@ endif
 .PHONY: goimports
 goimports:
 	find . -name "*.go" | fgrep -v vendor/ | xargs goimports -w -local github.com/deislabs/duffle
-

--- a/cmd/duffle/upgrade_test.go
+++ b/cmd/duffle/upgrade_test.go
@@ -29,7 +29,7 @@ func TestUpgradePersistsClaim(t *testing.T) {
 		Version: "0.1.0",
 		InvocationImages: []bundle.InvocationImage{
 			{
-				bundle.BaseImage{Image: "foo/bar:0.1.0", ImageType: "docker"},
+				BaseImage: bundle.BaseImage{Image: "foo/bar:0.1.0", ImageType: "docker"},
 			},
 		},
 	}

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -38,7 +38,7 @@ func mockBundle() *bundle.Bundle {
 		Version: "0.1.0",
 		InvocationImages: []bundle.InvocationImage{
 			{
-				bundle.BaseImage{Image: "foo/bar:0.1.0", ImageType: "docker"},
+				BaseImage: bundle.BaseImage{Image: "foo/bar:0.1.0", ImageType: "docker"},
 			},
 		},
 		Credentials: map[string]bundle.Location{

--- a/pkg/packager/export.go
+++ b/pkg/packager/export.go
@@ -39,9 +39,6 @@ func NewExporter(source, dest, logsDir string, l loader.Loader, thin, unsigned b
 	}
 	ctx := context.Background()
 	cli.NegotiateAPIVersion(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("cannot negotiate Docker client version: %v", err)
-	}
 
 	logs := filepath.Join(logsDir, "export-"+time.Now().Format("20060102150405"))
 

--- a/pkg/packager/import.go
+++ b/pkg/packager/import.go
@@ -40,9 +40,6 @@ func NewImporter(source, destination string, load loader.Loader, verbose bool) (
 		return nil, err
 	}
 	cli.NegotiateAPIVersion(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("cannot negotiate Docker client version: %v", err)
-	}
 
 	return &Importer{
 		Source:      source,


### PR DESCRIPTION
The lint pass is failing on `master`, and the only reason I see is that `golangci-lint` was silently updated, as we always use the last version.
That's why I pinned the tool to the current version to prevent from futur failures.

Here is the output:
```
golangci-lint run --config ./golangci.yml
cmd/duffle/upgrade_test.go:31:4: composites: `github.com/deislabs/duffle/pkg/bundle.InvocationImage` composite literal uses unkeyed fields (govet)
			{
			^
pkg/action/action_test.go:40:4: composites: `github.com/deislabs/duffle/pkg/bundle.InvocationImage` composite literal uses unkeyed fields (govet)
			{
			^
pkg/packager/export.go:42:9: nilness: impossible condition: nil != nil (govet)
	if err != nil {
	       ^
pkg/packager/import.go:43:9: nilness: impossible condition: nil != nil (govet)
	if err != nil {
	       ^
make: *** [lint] Error 1
Makefile:74: recipe for target 'lint' failed
```

Signed-off-by: Silvin Lubecki <silvin.lubecki@docker.com>