### PR TITLE
Remove insecure references from bundle actions command

### DIFF
--- a/cmd/duffle/bundle_actions.go
+++ b/cmd/duffle/bundle_actions.go
@@ -16,7 +16,6 @@ type bundleActionsCmd struct {
 	out          io.Writer
 	home         home.Home
 	bundle       string
-	insecure     bool
 	bundleIsFile bool
 }
 
@@ -36,18 +35,17 @@ func newBundleActionsCmd(w io.Writer) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&a.bundleIsFile, "bundle-is-file", "f", false, "Indicates that the bundle source is a file path")
-	cmd.Flags().BoolVarP(&a.insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
 
 	return cmd
 }
 
 func (a *bundleActionsCmd) run() error {
-	bundleFile, err := resolveBundleFilePath(a.bundle, a.home.String(), a.bundleIsFile, a.insecure)
+	bundleFile, err := resolveBundleFilePath(a.bundle, a.home.String(), a.bundleIsFile)
 	if err != nil {
 		return err
 	}
 
-	bun, err := loadBundle(bundleFile, a.insecure)
+	bun, err := loadBundle(bundleFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/duffle/bundle_actions_test.go
+++ b/cmd/duffle/bundle_actions_test.go
@@ -12,7 +12,6 @@ func TestBundleActions(t *testing.T) {
 		out:          out,
 		bundleIsFile: true,
 		bundle:       "./testdata/testbundle/actions-test-bundle.json",
-		insecure:     true,
 	}
 
 	if err := cmd.run(); err != nil {


### PR DESCRIPTION
This PR removes the `insecure` references from the bundle actions command.

I promise I'll stop merging PRs on Saturdays..

closes #699 