### PR TITLE
Well known custom actions

### DIFF
--- a/docs/guides/bundle-guide.md
+++ b/docs/guides/bundle-guide.md
@@ -52,7 +52,7 @@ case $action in
     upgrade)
     echo "Upgrade action"
     ;;
-    status)
+    io.cnab.status)
     echo "Status action"
     ;;
     *)

--- a/docs/guides/bundle-guide.md
+++ b/docs/guides/bundle-guide.md
@@ -52,9 +52,6 @@ case $action in
     upgrade)
     echo "Upgrade action"
     ;;
-    downgrade)
-    echo "Downgrade action"
-    ;;
     status)
     echo "Status action"
     ;;

--- a/docs/proposal/200-duffle.md
+++ b/docs/proposal/200-duffle.md
@@ -25,7 +25,7 @@ The following commands run a CNAB's applicable invocation image, each passing a 
 - `duffle install` captures the intent to install a bundle, and sets `CNAB_ACTION=install`.
 - `duffle upgrade` captures the intent to upgrade an existing installation with a bundle, and sets `CNAB_ACTION=upgrade`.
 - `duffle uninstall` captures the intent to uninstall an application, and sets `CNAB_ACTION=uninstall`.
-- `duffle status` captures the intent to determine the status of an application, and sets `CNAB_ACTION=status`.
+- `duffle status` captures the intent to determine the status of an application, and sets `CNAB_ACTION=io.cnab.status`.
 
 All of these actions accept [credential sets](201-credentialsets.md). `install` and `upgrade` accept parameters. (TODO: In the future, `uninstall` may also accept parameters).
 
@@ -35,7 +35,7 @@ Upgrade takes a claim's installation name as input, loads the claim, executes th
 
 Uninstall takes a claim's installation name, looks up the claim, executes the uninstall, and then destroys the claim.
 
-Status takes a claim's installation name, looks up a claim, and executes the status. Status never modifies the claim.
+Status takes a claim's installation name, looks up a claim, and executes the `io.cnab.status` action. Status never modifies the claim.
 
 ## Duffle List
 

--- a/examples/helloazure/cnab/app/run
+++ b/examples/helloazure/cnab/app/run
@@ -15,7 +15,7 @@ case $action in
     upgrade)
     echo "Upgrade action"
     ;;
-    status)
+    io.cnab.status)
     echo "Status action"
     ;;
     *)

--- a/examples/helloazure/cnab/app/run
+++ b/examples/helloazure/cnab/app/run
@@ -15,9 +15,6 @@ case $action in
     upgrade)
     echo "Upgrade action"
     ;;
-    downgrade)
-    echo "Downgrade action"
-    ;;
     status)
     echo "Status action"
     ;;

--- a/examples/helloworld/cnab/app/run
+++ b/examples/helloworld/cnab/app/run
@@ -17,9 +17,6 @@ case $action in
     upgrade)
     echo "Upgrade action"
     ;;
-    downgrade)
-    echo "Downgrade action"
-    ;;
     status)
     echo "Status action"
     ;;

--- a/examples/helloworld/cnab/app/run
+++ b/examples/helloworld/cnab/app/run
@@ -17,7 +17,7 @@ case $action in
     upgrade)
     echo "Upgrade action"
     ;;
-    status)
+    io.cnab.status)
     echo "Status action"
     ;;
     *)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -22,7 +22,6 @@ const stateful = false
 // - install
 // - upgrade
 // - uninstall
-// - downgrade
 // - status
 type Action interface {
 	// Run an action, and record the status in the given claim

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -22,7 +22,6 @@ const stateful = false
 // - install
 // - upgrade
 // - uninstall
-// - status
 type Action interface {
 	// Run an action, and record the status in the given claim
 	Run(*claim.Claim, credentials.Set) error

--- a/pkg/action/status.go
+++ b/pkg/action/status.go
@@ -15,14 +15,5 @@ type Status struct {
 
 // Run executes a status action in an image
 func (i *Status) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error {
-	invocImage, err := selectInvocationImage(i.Driver, c)
-	if err != nil {
-		return err
-	}
-
-	op, err := opFromClaim(claim.ActionStatus, stateful, c, invocImage, creds, w)
-	if err != nil {
-		return err
-	}
-	return i.Driver.Run(op)
+	return (&RunCustom{Driver: i.Driver, Action: "io.cnab.status"}).Run(c, creds, w)
 }

--- a/pkg/action/status_test.go
+++ b/pkg/action/status_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/deislabs/duffle/pkg/bundle"
 	"github.com/deislabs/duffle/pkg/claim"
 	"github.com/deislabs/duffle/pkg/driver"
 
@@ -13,15 +14,16 @@ import (
 
 func TestStatus_Run(t *testing.T) {
 	out := ioutil.Discard
-
+	b := mockBundle()
+	b.Actions["io.cnab.status"] = bundle.Action{}
 	st := &Status{Driver: &driver.DebugDriver{}}
 	c := &claim.Claim{
 		Created:    time.Time{},
 		Modified:   time.Time{},
 		Name:       "name",
 		Revision:   "revision",
-		Bundle:     mockBundle(),
 		Parameters: map[string]interface{}{},
+		Bundle:     b,
 	}
 
 	if err := st.Run(c, mockSet, out); err != nil {

--- a/pkg/claim/claim.go
+++ b/pkg/claim/claim.go
@@ -23,7 +23,6 @@ const (
 const (
 	ActionInstall   = "install"
 	ActionUpgrade   = "upgrade"
-	ActionDowngrade = "downgrade"
 	ActionUninstall = "uninstall"
 	ActionStatus    = "status"
 	ActionUnknown   = "unknown"
@@ -32,7 +31,7 @@ const (
 // Claim is an installation claim receipt.
 //
 // Claims reprsent information about a particular installation, and
-// provide the necessary data to upgrade, uninstall, and downgrade
+// provide the necessary data to upgrade and uninstall.
 // a CNAB package.
 type Claim struct {
 	Name       string                 `json:"name"`

--- a/pkg/claim/claim.go
+++ b/pkg/claim/claim.go
@@ -24,7 +24,6 @@ const (
 	ActionInstall   = "install"
 	ActionUpgrade   = "upgrade"
 	ActionUninstall = "uninstall"
-	ActionStatus    = "status"
 	ActionUnknown   = "unknown"
 )
 


### PR DESCRIPTION
* Status is no more a mandatory action, but it is now a [well known custom action](https://github.com/deislabs/cnab-spec/blob/master/804-well-known-custom-actions.md#well-known-custom-actions)
* Downgrade has been totally removed has it wasn't really implemented in duffle