### PR TITLE
ref(pkg/driver): update Lookup method to return error if not supported

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -22,8 +22,10 @@ func Lookup(name string) (Driver, error) {
 		return &DockerDriver{}, nil
 	case "debug":
 		return &DebugDriver{}, nil
-	default:
+	case "command":
 		return &CommandDriver{Name: name}, nil
+	default:
+		return nil, fmt.Errorf("unsupported driver: %s", name)
 	}
 }
 

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -10,8 +10,15 @@ import (
 var _ Driver = &DockerDriver{}
 var _ Driver = &DebugDriver{}
 
-func TestLookup_ExternalDriver(t *testing.T) {
+func TestLookup_UnsupportedDriver(t *testing.T) {
 	d, err := Lookup("no_such_driver")
+
+	assert.Nil(t, d)
+	assert.Error(t, err)
+}
+
+func TestLookup_CommandDriver(t *testing.T) {
+	d, err := Lookup("command")
 
 	assert.NoError(t, err)
 	assert.IsType(t, d, &CommandDriver{})


### PR DESCRIPTION
This refactor proposes to update the `Lookup` method in `driver.go` to return an error if the supplied driver name isn't explicitly supported.