### PR TITLE
Clarify what duffle is intended for

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 [![Waffle.io - Columns and their card count](https://badge.waffle.io/deislabs/duffle.svg?columns=In%20Progress,Needs%20Review,Done)](https://waffle.io/deislabs/duffle)
 
 
-Duffle is the reference implementation of the [CNAB Specification][cnab], a
-command-line tool to install and manage CNAB bundles. While you can build new
-bundles with duffle, we recommend using one of the [CNAB community
-tools][cnab-tools] that were designed to make authoring bundles easier.
+Duffle is the reference implementation of the [CNAB specification][cnab]. It
+provides a comprehensive mapping of _all_ features of the specification, serving
+both as a tool to install and manage bundles, and author bundles at a low level.
 
-To learn more about about CNAB and duffle, check out the [docs](docs/README.md).
+The community has created implementations of the CNAB spec with
+[opinionated takes on authoring bundles][cnab-tools]. Some even use Duffle's
+[libraries][cnab-go] to handle the CNAB implementation. If you want to make your own CNAB tooling, that is a great place to start!
+
+Learn more about about CNAB and Duffle, check out our [docs](docs/README.md).
 
 ## Getting Started
 
@@ -112,3 +115,4 @@ See the [Developer's Guide](docs/developing.md).
 
 [cnab]: https://cnab.io
 [cnab-tools]: https://cnab.io/community-projects/#tools
+[cnab-go]: https://github.com/deislabs/cnab-go

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ both as a tool to install and manage bundles, and author bundles at a low level.
 
 The community has created implementations of the CNAB spec with
 [opinionated takes on authoring bundles][cnab-tools]. Some even use Duffle's
-[libraries][cnab-go] to handle the CNAB implementation. If you want to make your own CNAB tooling, that is a great place to start!
+[libraries][cnab-sdk] to handle the CNAB implementation. If you want to make your own CNAB tooling, that is a great place to start!
 
 Learn more about about CNAB and Duffle, check out our [docs](docs/README.md).
 
@@ -115,4 +115,4 @@ See the [Developer's Guide](docs/developing.md).
 
 [cnab]: https://cnab.io
 [cnab-tools]: https://cnab.io/community-projects/#tools
-[cnab-go]: https://github.com/deislabs/cnab-go
+[cnab-sdk]: https://cnab.io/community-projects/#sdk

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 [![Waffle.io - Columns and their card count](https://badge.waffle.io/deislabs/duffle.svg?columns=In%20Progress,Needs%20Review,Done)](https://waffle.io/deislabs/duffle)
 
 
-Duffle is a command line tool that allows you to install and manage CNAB bundles. To learn more about about CNAB and duffle, check out the [docs](docs/README.md).
+Duffle is the reference implementation of the [CNAB Specification][cnab], a
+command-line tool to install and manage CNAB bundles. While you can build new
+bundles with duffle, we recommend using one of the [CNAB community
+tools][cnab-tools] that were designed to make authoring bundles easier.
+
+To learn more about about CNAB and duffle, check out the [docs](docs/README.md).
 
 ## Getting Started
 
@@ -104,3 +109,6 @@ Duffle is a command line tool that allows you to install and manage CNAB bundles
 ## Developing Duffle
 
 See the [Developer's Guide](docs/developing.md).
+
+[cnab]: https://cnab.io
+[cnab-tools]: https://cnab.io/community-projects/#tools


### PR DESCRIPTION
Duffle is the reference implementation of the spec. We should point people to the the community tools if they want to build new bundles so that they don't assume that duffle is the official tool for that, and get frustrated when it's super hard. 😀 

We keep a list of community run projects, like Docker Apps and Porter, that we can point to so that people can find a tool to fit their needs. I have an [open PR](https://github.com/deislabs/cnab.io/pull/12) to add Docker Apps to that page, but would like a review from someone at Docker first before I merge it. Maybe @silvin-lubecki can take a look?