### PR TITLE
Improve panic handling

### DIFF
--- a/cmd/duffle/main.go
+++ b/cmd/duffle/main.go
@@ -27,14 +27,6 @@ var (
 )
 
 func main() {
-	defer func() {
-		if r := recover(); r != nil {
-			if err, ok := r.(error); ok {
-				fmt.Fprint(os.Stderr, fmt.Sprintf("error occurred %+v", err))
-				must(err)
-			}
-		}
-	}()
 	rootCmd = newRootCmd(nil)
 	must(rootCmd.Execute())
 }


### PR DESCRIPTION
During development, panics with values which are not errors cause duffle to
exit silently and with exit code 0.

For instance:

panic("not yet implemented")

results in a silent exit.

Also, panics which are errors only result in the error being printed rather
than a stack trace.

It is better not to recover from the panic and allow the standard diagnostics
to be printed. This shouldn't affect normal UX since panics indicate a
programming error.