### PR TITLE
Fix constraint for cnab-go to point to origin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -180,7 +180,6 @@
   version = "v1.1.1"
 
 [[projects]]
-  branch = "add-duffle-types"
   digest = "1:26492e179ef4aebabd64482e08144f77273a817f0ad865021d4c7172d78c9892"
   name = "github.com/deislabs/cnab-go"
   packages = [
@@ -192,8 +191,7 @@
     "utils/crud",
   ]
   pruneopts = "NUT"
-  revision = "9cd2d85086f9a1e31ac1c59e6ec4f6bb36c2f980"
-  source = "github.com/radu-matei/cnab-go"
+  revision = "9028f0f800a40977c2e49a38be764978cfe82324"
 
 [[projects]]
   digest = "1:e71d64468873ca819b91b975e67e71f349a89f41ab38040bcbd8840f5e193654"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -65,9 +65,8 @@
 
 [[constraint]]
   name = "github.com/deislabs/cnab-go"
-  source = "github.com/radu-matei/cnab-go"
-  branch = "add-duffle-types"
-
+  revision = "9028f0f800a40977c2e49a38be764978cfe82324"
+  
 [[override]]
   name = "k8s.io/apimachinery"
   revision = "kubernetes-1.11.2"


### PR DESCRIPTION
#742 included the branch of `deislabs/cnab-go` from the PR, which should have been updated before merging.. This PR updates the constraint to point to a revision of origin, rather than the PR.