### PR TITLE
ci(brigade.js): run test GH Checks for master branch

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -161,13 +161,8 @@ function checkRequested(e, p) {
 // Here we can add additional Check Runs, which will run in parallel and
 // report their results independently to GitHub
 function runSuite(e, p) {
-  // For the master branch, we build and publish images in response to the push
-  // event. We test as a precondition for doing that, so we DON'T test here
-  // for the master branch.
-  if (e.revision.ref != "master") {
-    // For now, this is the one-stop shop running build, lint and test targets
-    return runTests(e, p);
-  }
+  // For now, this is the one-stop shop running build, lint and test targets
+  return runTests(e, p);
 }
 
 // runTests is a Check Run that is run as part of a Checks Suite


### PR DESCRIPTION
This removes the `if not master` check in `runSuite` so that Brigade runs the same test checks on master (and, thus, updates this branch's status at https://github.com/deislabs/duffle/branches properly).