### PR TITLE
Use standard Go 1.12 image for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/lightweight-docker-go:v0.7.0
+FROM golang:1.12-alpine
 ARG LDFLAGS
 ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/deislabs/duffle

--- a/brigade.js
+++ b/brigade.js
@@ -3,7 +3,7 @@ const { events, Job, Group } = require("brigadier");
 const projectOrg = "deislabs";
 const projectName = "duffle";
 
-const goImg = "quay.io/deis/lightweight-docker-go:v0.7.0";
+const goImg = "golang:1.12-stretch";
 const gopath = "/go"
 const localPath = gopath + `/src/github.com/${projectOrg}/${projectName}`;
 
@@ -67,7 +67,7 @@ function test() {
   // Run Go unit tests
   job.tasks = [
     `cd ${localPath}`,
-    "make verify-vendored-code lint test"
+    "make install-dep verify-vendored-code install-golangci-lint lint test"
   ];
   return job;
 }

--- a/pkg/driver/kubernetes.go
+++ b/pkg/driver/kubernetes.go
@@ -350,7 +350,7 @@ func generateFileSecret(files map[string]string) (*v1.Secret, []v1.VolumeMount) 
 
 	i := 0
 	for path, contents := range files {
-		key := strings.Replace(filepath.ToSlash(path), "/", "_", -1)
+		key := strings.ReplaceAll(filepath.ToSlash(path), "/", "_")
 		data[key] = contents
 		mounts[i] = v1.VolumeMount{
 			Name:      k8sFileSecretVolume,


### PR DESCRIPTION
This allows Go 1.12 features to be used and so we revert an earlier commit.

An alternative would be to bump `quay.io/deis/lightweight-docker-go` to use a later version of Go, but it's probably safer to get out of that game and use the more widely supported golang image instead. Also it's not obvious how to make `quay.io/deis/lightweight-docker-go` usable by all maintainers.

Note that `SKIP_DOCKER=true` is currently undocumented and so there is no action for users to take. 
(Those who use `SKIP_DOCKER=true` should know what they are doing.)