### PR TITLE
fix schemaVersion and Version export

### DIFF
--- a/cmd/duffle/create_test.go
+++ b/cmd/duffle/create_test.go
@@ -45,7 +45,7 @@ func TestCreateCmd(t *testing.T) {
 	}
 
 	// This is the Canonical JSON representation. http://wiki.laptop.org/go/Canonical_JSON
-	expected := `{"description":"A short description of your bundle","invocationImages":{"cnab":{"builder":"docker","configuration":{"registry":"deislabs"},"name":"cnab"}},"keywords":["test-bundle","cnab","tutorial"],"maintainers":[{"email":"john.doe@example.com","name":"John Doe","url":"https://example.com"},{"email":"jane.doe@example.com","name":"Jane Doe","url":"https://example.com"}],"name":"test-bundle","version":"0.1.0"}`
+	expected := `{"description":"A short description of your bundle","invocationImages":{"cnab":{"builder":"docker","configuration":{"registry":"deislabs"},"name":"cnab"}},"keywords":["test-bundle","cnab","tutorial"],"maintainers":[{"email":"john.doe@example.com","name":"John Doe","url":"https://example.com"},{"email":"jane.doe@example.com","name":"Jane Doe","url":"https://example.com"}],"name":"test-bundle","schemaVersion":"v1.0.0-WD","version":"0.1.0"}`
 
 	if string(mbytes) != expected {
 		t.Errorf("Expected duffle.json output to look like this:\n\n%s\n\nGot:\n\n%s", expected, string(mbytes))

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -67,14 +67,16 @@ func (b *Builder) PrepareBuild(bldr *Builder, mfst *manifest.Manifest, appDir st
 	}
 
 	bf := &bundle.Bundle{
-		Name:        ctx.Manifest.Name,
-		Description: ctx.Manifest.Description,
-		Images:      ctx.Manifest.Images,
-		Keywords:    ctx.Manifest.Keywords,
-		Maintainers: ctx.Manifest.Maintainers,
-		Actions:     ctx.Manifest.Actions,
-		Parameters:  ctx.Manifest.Parameters,
-		Credentials: ctx.Manifest.Credentials,
+		Name:          ctx.Manifest.Name,
+		Description:   ctx.Manifest.Description,
+		Images:        ctx.Manifest.Images,
+		Keywords:      ctx.Manifest.Keywords,
+		Maintainers:   ctx.Manifest.Maintainers,
+		Actions:       ctx.Manifest.Actions,
+		Parameters:    ctx.Manifest.Parameters,
+		Credentials:   ctx.Manifest.Credentials,
+		Version:       ctx.Manifest.Version,
+		SchemaVersion: ctx.Manifest.SchemaVersion,
 	}
 
 	for _, imb := range imageBuilders {

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -52,10 +52,11 @@ func (tc testImage) Build(ctx context.Context, log io.WriteCloser) error {
 
 func TestPrepareBuild(t *testing.T) {
 	mfst := &manifest.Manifest{
-		Name:        "foo",
-		Version:     "0.1.0",
-		Description: "description",
-		Keywords:    []string{"test"},
+		Name:          "foo",
+		Version:       "0.1.0",
+		SchemaVersion: "v1.0.0",
+		Description:   "description",
+		Keywords:      []string{"test"},
 		InvocationImages: map[string]*manifest.InvocationImage{
 			"cnab": {
 				Name:          "cnab",
@@ -90,6 +91,12 @@ func TestPrepareBuild(t *testing.T) {
 		t.Fatalf("expected there to be 1 image, got %d. Full output: %v", len(b.Images), b)
 	}
 
+	if b.Version != mfst.Version {
+		t.Errorf("expected version %v, got %v", mfst.Version, b.Version)
+	}
+	if b.SchemaVersion != mfst.SchemaVersion {
+		t.Errorf("expected schemaVersion %v, got %v", mfst.SchemaVersion, b.SchemaVersion)
+	}
 	expected := bundle.InvocationImage{}
 	expected.Image = "cnab:0.1.0"
 	expected.ImageType = "docker"

--- a/pkg/duffle/manifest/create.go
+++ b/pkg/duffle/manifest/create.go
@@ -31,15 +31,18 @@ COPY app /cnab/app
 CMD ["/cnab/app/run"]
 `
 
+const schemaVersion = "v1.0.0-WD"
+
 // Scaffold takes a path and creates a minimal duffle manifest (duffle.json)
 //  and scaffolds the components in that manifest
 func Scaffold(path string) error {
 	name := filepath.Base(path)
 	m := &Manifest{
-		Name:        name,
-		Version:     "0.1.0",
-		Description: "A short description of your bundle",
-		Keywords:    []string{name, "cnab", "tutorial"},
+		Name:          name,
+		Version:       "0.1.0",
+		SchemaVersion: schemaVersion,
+		Description:   "A short description of your bundle",
+		Keywords:      []string{name, "cnab", "tutorial"},
 		Maintainers: []bundle.Maintainer{
 			{
 				Name:  "John Doe",

--- a/pkg/duffle/manifest/manifest.go
+++ b/pkg/duffle/manifest/manifest.go
@@ -14,6 +14,7 @@ import (
 type Manifest struct {
 	Name             string                       `json:"name" mapstructure:"name"`
 	Version          string                       `json:"version" mapstructure:"version"`
+	SchemaVersion    string                       `json:"schemaVersion" mapstructure:"schemaVersion"`
 	Description      string                       `json:"description,omitempty" mapstructure:"description"`
 	Keywords         []string                     `json:"keywords,omitempty" mapstructure:"keywords"`
 	Maintainers      []bundle.Maintainer          `json:"maintainers,omitempty" mapstructure:"maintainers"`


### PR DESCRIPTION
Copy the version and schemaVersion from manifest to bundle.
Initialize the manifest with a valid schemaVersion

closes #789 