### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,6 @@
 # Global Owners: These members are Core Maintainers of Duffle
 # Only certain critical files should cause all the owners to be added automatically to PR reviews
 # See https://github.com/deislabs/duffle/issues/745 for the rationale
-CODEOWNERS @technosophos @michellenoorali @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki
-LICENSE    @technosophos @michellenoorali @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki
-NOTICE     @technosophos @michellenoorali @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki
+CODEOWNERS @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki
+LICENSE    @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki
+NOTICE     @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki


### PR DESCRIPTION
@michelleN  has moved to a new team in Microsoft and isn't working on CNAB related things anymore, so this removes her from the CODEOWNERS file so she doesn't get any unneeded notifications from github.

A fond farewell to @michelleN 👋 