### PR TITLE
Reduce test verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ lint:
 
 .PHONY: test
 test:
-	$(DOCKER_CMD) go test -v ./...
+	$(DOCKER_CMD) go test ./...
 
 ################################################################################
 # Build / Publish                                                              #


### PR DESCRIPTION
Rarely is the additional output from the -v tag useful in testing