### PR TITLE
Fix style inconsistencies in short usage doc strings

### DIFF
--- a/cmd/duffle/bundle_actions.go
+++ b/cmd/duffle/bundle_actions.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const bundleActionsDesc = ` Lists all actions available in a bundle`
+const bundleActionsDesc = `list all actions available in a bundle`
 
 type bundleActionsCmd struct {
 	out          io.Writer

--- a/cmd/duffle/bundle_list.go
+++ b/cmd/duffle/bundle_list.go
@@ -61,7 +61,7 @@ func newBundleListCmd(w io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "lists bundles pulled or built and stored locally",
+		Short:   "list bundles pulled or built and stored locally",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			home := home.Home(homePath())
 			references, err := searchLocal(home)


### PR DESCRIPTION
Most short usage doc strings are in the infinitive ("show the foo", "delete the bar") and do not have an initial capital.  A couple of strings were inconsistent with this convention; this PR fixes them.