### PR TITLE
Return readable format by default from duffle bundle show

### DIFF
--- a/cmd/duffle/bundle_show.go
+++ b/cmd/duffle/bundle_show.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
 
+	"github.com/docker/go/canonical/json"
 	"github.com/spf13/cobra"
 )
 
@@ -58,22 +58,21 @@ func (bsc *bundleShowCmd) run() error {
 		return err
 	}
 
-	if bsc.raw {
-		f, err := os.Open(bundleFile)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		_, err = io.Copy(bsc.w, f)
-		return err
-	}
-
 	bun, err := loadBundle(bundleFile)
 	if err != nil {
 		return err
 	}
 
-	_, err = bun.WriteTo(bsc.w)
+	if bsc.raw {
+		_, err = bun.WriteTo(bsc.w)
+		return err
+	}
+
+	d, err := json.MarshalIndent(bun, " ", " ")
+	if err != nil {
+		return err
+	}
+	_, err = bsc.w.Write(d)
 
 	return err
 }


### PR DESCRIPTION
closes #821 
closes #665 
closes #702

This PR updates `duffle bundle show` to print indented JSON by default.

It can also be argued that a method for writing indented bundles can be added on the bundle structure - however, I think the format in which bundles are shown should be left for individual tools to decide.
That being said, I'm happy to discuss that.

cc @itowlson 

To test:
```
$ duffle bundle show buildtest                                                                                                             
{
  "schemaVersion": "v1.0.0-WD",
  "name": "buildtest",
  "version": "0.1.0",
  "description": "A short description of your bundle",
  "keywords": [
   "buildtest",
   "cnab",
   "tutorial"
  ],
  "maintainers": [
   {
    "name": "John Doe",
    "email": "john.doe@example.com",
    "url": "https://example.com"
   },
   {
    "name": "Jane Doe",
    "email": "jane.doe@example.com",
    "url": "https://example.com"
   }
  ],
  "invocationImages": [
   {
    "imageType": "docker",
    "image": "deislabs/buildtest-cnab:07a9017ca57fb97e8d2ecf92bedb255a87855c51"
   }
  ]
 }
$ duffle bundle show buildtest --raw

{"description":"A short description of your bundle","invocationImages":[{"image":"deislabs/buildtest-cnab:07a9017ca57fb97e8d2ecf92bedb255a87855c51","imageType":"docker"}],"keywords":["buildtest","cnab","tutorial"],"maintainers":[{"email":"john.doe@example.com","name":"John Doe","url":"https://example.com"},{"email":"jane.doe@example.com","name":"Jane Doe","url":"https://example.com"}],"name":"buildtest","schemaVersion":"v1.0.0-WD","version":"0.1.0"}
```