### PR TITLE
ref(pkg/driver): remove pkg/driver; use cnab-go for needed logic

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -200,7 +200,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:e86556f6f91e6c175ac44965165c1edbf75a978dd85442cef7415059f86a4bc3"
+  digest = "1:4e78f0d8768dbef11dc34305aa85259b9db277cd9df088f4beef0adc0b87e88a"
   name = "github.com/deislabs/cnab-go"
   packages = [
     "action",
@@ -213,6 +213,7 @@
     "driver/command",
     "driver/docker",
     "driver/kubernetes",
+    "driver/lookup",
     "utils/crud",
   ]
   pruneopts = "NUT"
@@ -1249,9 +1250,7 @@
     "github.com/deislabs/cnab-go/claim",
     "github.com/deislabs/cnab-go/credentials",
     "github.com/deislabs/cnab-go/driver",
-    "github.com/deislabs/cnab-go/driver/command",
-    "github.com/deislabs/cnab-go/driver/docker",
-    "github.com/deislabs/cnab-go/driver/kubernetes",
+    "github.com/deislabs/cnab-go/driver/lookup",
     "github.com/deislabs/cnab-go/utils/crud",
     "github.com/docker/cli/cli/command",
     "github.com/docker/cli/cli/command/image/build",

--- a/cmd/duffle/main.go
+++ b/cmd/duffle/main.go
@@ -14,10 +14,10 @@ import (
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/credentials"
 	"github.com/deislabs/cnab-go/driver"
+	"github.com/deislabs/cnab-go/driver/lookup"
 	"github.com/deislabs/cnab-go/utils/crud"
 	"github.com/spf13/cobra"
 
-	duffleDriver "github.com/deislabs/duffle/pkg/driver"
 	"github.com/deislabs/duffle/pkg/duffle/home"
 	"github.com/deislabs/duffle/pkg/reference"
 )
@@ -112,7 +112,7 @@ func must(err error) {
 
 // prepareDriver prepares a driver per the user's request.
 func prepareDriver(driverName string, relMap string) (driver.Driver, error) {
-	driverImpl, err := duffleDriver.Lookup(driverName)
+	driverImpl, err := lookup.Lookup(driverName)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/deislabs/cnab-go/driver/lookup/lookup.go
+++ b/vendor/github.com/deislabs/cnab-go/driver/lookup/lookup.go
@@ -1,4 +1,4 @@
-package driver
+package lookup
 
 import (
 	"fmt"


### PR DESCRIPTION
Removes the `driver` pkg.

- the command driver is already in deislabs/cnab-go
- the needed `Lookup` method ~~is intended to be~~ was ported in https://github.com/deislabs/cnab-go/pull/97

TODO:
  - [x] replace `vendor` mod with appropriate cnab-go bump (didn't go the route of updating Gopkg.toml w/ my source/branch b/c it's based on latest cnab-go, which includes many changes;  see https://github.com/deislabs/duffle/pull/827)