### PR TITLE
Add a .gitattributes file to force LF on .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Declare .sh files will always have LF line endings on checkout.
+*/*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Declare .sh files will always have LF line endings on checkout.
-*/*.sh text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
This adds a .gitattributes file to force `LF` line endings on windows. See https://help.github.com/en/articles/configuring-git-to-handle-line-endings#per-repository-settings for more info. 

Fixes #837 