### PR TITLE
Bump cnab-go: Don't fetch outputs when none are defined

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -200,7 +200,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:4e78f0d8768dbef11dc34305aa85259b9db277cd9df088f4beef0adc0b87e88a"
+  digest = "1:0fef6f49fe9577b57632f0f8864238fb65d5b8c7a3611620eb144cdde582bb3c"
   name = "github.com/deislabs/cnab-go"
   packages = [
     "action",
@@ -217,8 +217,8 @@
     "utils/crud",
   ]
   pruneopts = "NUT"
-  revision = "1ef7d96a46de6e4205de8eedd80e3cf387fef72b"
-  version = "v0.3.1-beta1"
+  revision = "0ce7659aab8dbd37cc912ea64cb78f403534de42"
+  version = "v0.3.2-beta1"
 
 [[projects]]
   digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,7 +57,7 @@
 
 [[constraint]]
   name = "github.com/deislabs/cnab-go"
-  version = "v0.3.1-beta1"
+  version = "v0.3.2-beta1"
 
 [[override]]
   name = "github.com/google/go-containerregistry"

--- a/vendor/github.com/deislabs/cnab-go/action/action.go
+++ b/vendor/github.com/deislabs/cnab-go/action/action.go
@@ -161,11 +161,6 @@ func selectInvocationImage(d driver.Driver, c *claim.Claim) (bundle.InvocationIm
 
 	for _, ii := range c.Bundle.InvocationImages {
 		if d.Handles(ii.ImageType) {
-			if c.RelocationMap != nil {
-				if img, ok := c.RelocationMap[ii.Image]; ok {
-					ii.Image = img
-				}
-			}
 			return ii, nil
 		}
 	}

--- a/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
@@ -98,11 +98,6 @@ type InvocationImage struct {
 	BaseImage `yaml:",inline"`
 }
 
-// ImageRelocationMap stores the relocated images
-// The key is the Image in bundle.json and the value is the new Image
-// from the relocated registry
-type ImageRelocationMap map[string]string
-
 // Location provides the location where a value should be written in
 // the invocation image.
 //

--- a/vendor/github.com/deislabs/cnab-go/claim/claim.go
+++ b/vendor/github.com/deislabs/cnab-go/claim/claim.go
@@ -40,11 +40,11 @@ type Claim struct {
 	Created    time.Time              `json:"created"`
 	Modified   time.Time              `json:"modified"`
 	Bundle     *bundle.Bundle         `json:"bundle"`
-	Result     Result                 `json:"result"`
-	Parameters map[string]interface{} `json:"parameters"`
+	Result     Result                 `json:"result,omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
 	// Outputs is a map from the names of outputs (defined in the bundle) to the contents of the files.
-	Outputs       map[string]interface{}    `json:"outputs"`
-	RelocationMap bundle.ImageRelocationMap `json:"relocationMap"`
+	Outputs map[string]interface{} `json:"outputs,omitempty"`
+	Custom  interface{}            `json:"custom,omitempty"`
 }
 
 // ValidName is a regular expression that indicates whether a name is a valid claim name.
@@ -67,9 +67,8 @@ func New(name string) (*Claim, error) {
 			Action: ActionUnknown,
 			Status: StatusUnknown,
 		},
-		Parameters:    map[string]interface{}{},
-		Outputs:       map[string]interface{}{},
-		RelocationMap: bundle.ImageRelocationMap{},
+		Parameters: map[string]interface{}{},
+		Outputs:    map[string]interface{}{},
 	}, nil
 }
 


### PR DESCRIPTION
This bumps cnab-go to pull in the fix for fetching outputs when none are defined https://github.com/deislabs/cnab-go/pull/111.

Fixes #839 