### PR TITLE
Allow duffle upgrade to accept a thick bundle

### DIFF
--- a/cmd/duffle/upgrade_test.go
+++ b/cmd/duffle/upgrade_test.go
@@ -29,8 +29,9 @@ func TestUpgradePersistsClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 	instClaim.Bundle = &bundle.Bundle{
-		Name:    "bar",
-		Version: "0.1.0",
+		Name:          "bar",
+		Version:       "0.1.0",
+		SchemaVersion: "v1.0.0-WD",
 		InvocationImages: []bundle.InvocationImage{
 			{
 				BaseImage: bundle.BaseImage{Image: "foo/bar:0.1.0", ImageType: "docker"},


### PR DESCRIPTION
Also validate the bundle being used to upgrade.

Fixes https://github.com/deislabs/duffle/issues/845