### PR TITLE
fix(brigade.js): prevent token leak if github-release fails

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -97,6 +97,7 @@ function githubRelease(p, tag) {
     "GITHUB_REPO": parts[1],
     "GITHUB_TOKEN": p.secrets.ghToken,
   };
+  job.shell = "/bin/bash";
   job.tasks = [
     "go get github.com/aktau/github-release",
     `cd ${localPath}`,
@@ -105,9 +106,10 @@ function githubRelease(p, tag) {
     `github-release release \
       -t ${tag} \
       -n "${parts[1]} ${tag}" \
-      -d "$(git log --no-merges --pretty=format:'- %s %H (%aN)' HEAD ^$last_tag)" \
-      || echo "release ${tag} exists"`,
-    `for bin in ./bin/*; do github-release upload -f $bin -n $(basename $bin) -t ${tag}; done`
+      -d "$(git log --no-merges --pretty=format:'- %s %H (%aN)' HEAD ^$last_tag)" 2>&1 | sed -e "s/\${GITHUB_TOKEN}/<REDACTED>/"`,
+    `for bin in ./bin/*; do \
+      github-release upload -f $bin -n $(basename $bin) -t ${tag} 2>&1 | sed -e "s/\${GITHUB_TOKEN}/<REDACTED>/"; \
+    done`
   ];
   console.log(job.tasks);
   console.log(`releases at https://github.com/${p.repo.name}/releases/tag/${tag}`);


### PR DESCRIPTION
We discovered that the utility used to create a GH release and upload binaries _may_ leak the auth token in an error scenario, hence the need to filter the output.

Tested via intentionally setting one of the env vars that this tool uses to determine repo (`GITHUB_REPO`) to an invalid value and we see:

```
 $ k logs release-01dkcs3gpydtxyh9hhjan6jsp4
bash -c "LDFLAGS=\"-w -s -X github.com/deislabs/duffle/pkg/version.Version=0.3.2-vdicetest\" scripts/build.sh"
building linux-amd64
building windows-amd64
building darwin-amd64
error: github returned 404 Not Found
error: expected '200 OK' but received '404 Not Found' (url: https://api.github.com/repos/vdice/testfakerepo/releases?access_token=<REDACTED>&per_page=100)
error: expected '200 OK' but received '404 Not Found' (url: https://api.github.com/repos/vdice/testfakerepo/releases?access_token=<REDACTED>&per_page=100)
error: expected '200 OK' but received '404 Not Found' (url: https://api.github.com/repos/vdice/testfakerepo/releases?access_token=<REDACTED>&per_page=100)
```

Seemingly the `github-release upload ...` invocation is the culprit for the token leak, but I also added a filter to the preceeding `github-release release ...` invocation.

Additionally, I removed the `|| echo "release ${tag} exists"` as it was rendered moot now that we pipe to `sed` and lose the return code, but this case/cause remains evident from the message returned from `github-release`, e.g.,

```
error: github returned 422 Unprocessable Entity (this is probably because the release already exists)
```