### PR TITLE
Add shortcut for specifying version during `duffle bundle rm`

### DIFF
--- a/cmd/duffle/bundle_remove.go
+++ b/cmd/duffle/bundle_remove.go
@@ -46,7 +46,7 @@ func newBundleRemoveCmd(w io.Writer) *cobra.Command {
 			return remove.run()
 		},
 	}
-	cmd.Flags().StringVar(&remove.versions, "version", "", "A version or SemVer2 version range")
+	cmd.Flags().StringVarP(&remove.versions, "version", "r", "", "A version or SemVer2 version range")
 
 	return cmd
 }


### PR DESCRIPTION
Fixes Issue #692