### PR TITLE
Bump cnab-go to v0.4.0-beta1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -200,7 +200,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:e76d4462364133154f9fc42aef3f3e5be6eb766017cfd1f8fbf6873673727464"
+  digest = "1:48f2d47b8f38bc88e0381a2a44ed2a8ccb12f268b71fe5aefa528e25a6f7256d"
   name = "github.com/deislabs/cnab-go"
   packages = [
     "action",
@@ -217,8 +217,8 @@
     "utils/crud",
   ]
   pruneopts = "NUT"
-  revision = "f8deb5c9bd12a94974feb03729f11e9da8dcd2c3"
-  version = "v0.3.3-beta1"
+  revision = "93515c713a91d6da48b5a9c68e4b0502d8d39963"
+  version = "v0.4.0-beta1"
 
 [[projects]]
   digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,7 +57,7 @@
 
 [[constraint]]
   name = "github.com/deislabs/cnab-go"
-  version = "v0.3.3-beta1"
+  version = "v0.4.0-beta1"
 
 [[override]]
   name = "github.com/google/go-containerregistry"
@@ -94,8 +94,3 @@
 [[override]]
   name = "golang.org/x/sys"
   revision = "f49334f85ddcf0f08d7fb6dd7363e9e6d6b777eb"
-
-[[constraint]]
-  # version imported by k8s.io/client-go @ kubernetes-1.11.2
-  name = "github.com/Azure/go-autorest"
-  revision = "1ff28809256a84bb6966640ff3d0371af82ccba4"

--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -151,7 +151,7 @@ func (i *installCmd) run() error {
 		Driver: driverImpl,
 	}
 	fmt.Fprintf(i.out, "Executing install action...\n")
-	err = inst.Run(c, creds, i.out)
+	err = inst.Run(c, creds, setOut(i.out))
 
 	// Even if the action fails, we want to store a claim. This is because
 	// we cannot know, based on a failure, whether or not any resources were

--- a/cmd/duffle/main.go
+++ b/cmd/duffle/main.go
@@ -149,7 +149,7 @@ func (d *driverWithRelocationMapping) Run(op *driver.Operation) (driver.Operatio
 		op.Files["/cnab/app/relocation-mapping.json"] = d.relMapping
 
 		var err error
-		op.Image, err = d.relocateImage(op.Image)
+		op.Image.Image, err = d.relocateImage(op.Image.Image)
 		if err != nil {
 			return driver.OperationResult{}, err
 		}

--- a/cmd/duffle/operation_configuration.go
+++ b/cmd/duffle/operation_configuration.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"io"
+
+	"github.com/deislabs/cnab-go/action"
+	"github.com/deislabs/cnab-go/driver"
+)
+
+func setOut(w io.Writer) action.OperationConfigFunc {
+	return func(op *driver.Operation) error {
+		op.Out = w
+		return nil
+	}
+}

--- a/cmd/duffle/run.go
+++ b/cmd/duffle/run.go
@@ -80,7 +80,7 @@ Credentials and parameters may be passed to the bundle during a target action.
 			}
 
 			fmt.Fprintf(w, "Executing custom action %q for release %q", target, claimName)
-			err = action.Run(&c, creds, cmd.OutOrStdout())
+			err = action.Run(&c, creds, setOut(cmd.OutOrStdout()))
 			if actionDef := c.Bundle.Actions[target]; !actionDef.Modifies {
 				// Do not store a claim for non-mutating actions.
 				return err

--- a/cmd/duffle/status.go
+++ b/cmd/duffle/status.go
@@ -70,7 +70,7 @@ reason, it may need the same credentials used to install.
 			// TODO: Do we pass new values in here? Or just from Claim?
 			action := &action.Status{Driver: driverImpl}
 			fmt.Println("Executing status action in bundle...")
-			return action.Run(&c, creds, cmd.OutOrStdout())
+			return action.Run(&c, creds, setOut(cmd.OutOrStdout()))
 		},
 	}
 	cmd.Flags().StringVarP(&statusDriver, "driver", "d", "docker", "Specify a driver name")

--- a/cmd/duffle/uninstall.go
+++ b/cmd/duffle/uninstall.go
@@ -111,7 +111,7 @@ func (un *uninstallCmd) run() error {
 	}
 
 	fmt.Fprintln(un.out, "Executing uninstall action...")
-	if err := uninst.Run(&claim, creds, un.out); err != nil {
+	if err := uninst.Run(&claim, creds, setOut(un.out)); err != nil {
 		return fmt.Errorf("could not uninstall %q: %s", un.name, err)
 	}
 	return claimStorage().Delete(un.name)

--- a/cmd/duffle/upgrade.go
+++ b/cmd/duffle/upgrade.go
@@ -126,7 +126,7 @@ func (up *upgradeCmd) run() error {
 	upgr := &action.Upgrade{
 		Driver: driverImpl,
 	}
-	err = upgr.Run(&claim, creds, up.out)
+	err = upgr.Run(&claim, creds, setOut(up.out))
 
 	// persist the claim, regardless of the success of the upgrade action
 	persistErr := claimStorage().Store(claim)

--- a/vendor/github.com/deislabs/cnab-go/action/action.go
+++ b/vendor/github.com/deislabs/cnab-go/action/action.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"strings"
 
@@ -28,7 +27,7 @@ const stateful = false
 // - status
 type Action interface {
 	// Run an action, and record the status in the given claim
-	Run(*claim.Claim, credentials.Set, io.Writer) error
+	Run(*claim.Claim, credentials.Set, ...OperationConfigFunc) error
 }
 
 func golangTypeToJSONType(value interface{}) (string, error) {
@@ -188,7 +187,7 @@ func appliesToAction(action string, parameter bundle.Parameter) bool {
 	return false
 }
 
-func opFromClaim(action string, stateless bool, c *claim.Claim, ii bundle.InvocationImage, creds credentials.Set, w io.Writer) (*driver.Operation, error) {
+func opFromClaim(action string, stateless bool, c *claim.Claim, ii bundle.InvocationImage, creds credentials.Set) (*driver.Operation, error) {
 	env, files, err := creds.Expand(c.Bundle, stateless)
 	if err != nil {
 		return nil, err
@@ -227,13 +226,11 @@ func opFromClaim(action string, stateless bool, c *claim.Claim, ii bundle.Invoca
 		Action:       action,
 		Installation: c.Name,
 		Parameters:   c.Parameters,
-		Image:        ii.Image,
-		ImageType:    ii.ImageType,
+		Image:        ii,
 		Revision:     c.Revision,
 		Environment:  env,
 		Files:        files,
 		Outputs:      outputs,
-		Out:          w,
 	}, nil
 }
 

--- a/vendor/github.com/deislabs/cnab-go/action/install.go
+++ b/vendor/github.com/deislabs/cnab-go/action/install.go
@@ -1,8 +1,6 @@
 package action
 
 import (
-	"io"
-
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/credentials"
 	"github.com/deislabs/cnab-go/driver"
@@ -14,13 +12,18 @@ type Install struct {
 }
 
 // Run performs an installation and updates the Claim accordingly
-func (i *Install) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error {
+func (i *Install) Run(c *claim.Claim, creds credentials.Set, opCfgs ...OperationConfigFunc) error {
 	invocImage, err := selectInvocationImage(i.Driver, c)
 	if err != nil {
 		return err
 	}
 
-	op, err := opFromClaim(claim.ActionInstall, stateful, c, invocImage, creds, w)
+	op, err := opFromClaim(claim.ActionInstall, stateful, c, invocImage, creds)
+	if err != nil {
+		return err
+	}
+
+	err = OperationConfigs(opCfgs).ApplyConfig(op)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/deislabs/cnab-go/action/operation_configs.go
+++ b/vendor/github.com/deislabs/cnab-go/action/operation_configs.go
@@ -1,0 +1,26 @@
+package action
+
+import (
+	"github.com/deislabs/cnab-go/driver"
+)
+
+// OperationConfigFunc is a configuration function that can be applied to an
+// operation.
+type OperationConfigFunc func(op *driver.Operation) error
+
+// OperationConfigs is a set of configuration functions that can be applied as a
+// unit to an operation.
+type OperationConfigs []OperationConfigFunc
+
+// ApplyConfig safely applies the configuration function to the operation, if
+// defined, and stops immediately upon the first error.
+func (cfgs OperationConfigs) ApplyConfig(op *driver.Operation) error {
+	var err error
+	for _, cfg := range cfgs {
+		err = cfg(op)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/deislabs/cnab-go/action/status.go
+++ b/vendor/github.com/deislabs/cnab-go/action/status.go
@@ -1,8 +1,6 @@
 package action
 
 import (
-	"io"
-
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/credentials"
 	"github.com/deislabs/cnab-go/driver"
@@ -14,13 +12,18 @@ type Status struct {
 }
 
 // Run executes a status action in an image
-func (i *Status) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error {
+func (i *Status) Run(c *claim.Claim, creds credentials.Set, opCfgs ...OperationConfigFunc) error {
 	invocImage, err := selectInvocationImage(i.Driver, c)
 	if err != nil {
 		return err
 	}
 
-	op, err := opFromClaim(claim.ActionStatus, stateful, c, invocImage, creds, w)
+	op, err := opFromClaim(claim.ActionStatus, stateful, c, invocImage, creds)
+	if err != nil {
+		return err
+	}
+
+	err = OperationConfigs(opCfgs).ApplyConfig(op)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/deislabs/cnab-go/action/uninstall.go
+++ b/vendor/github.com/deislabs/cnab-go/action/uninstall.go
@@ -1,8 +1,6 @@
 package action
 
 import (
-	"io"
-
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/credentials"
 	"github.com/deislabs/cnab-go/driver"
@@ -14,13 +12,18 @@ type Uninstall struct {
 }
 
 // Run performs the uninstall steps and updates the Claim
-func (u *Uninstall) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error {
+func (u *Uninstall) Run(c *claim.Claim, creds credentials.Set, opCfgs ...OperationConfigFunc) error {
 	invocImage, err := selectInvocationImage(u.Driver, c)
 	if err != nil {
 		return err
 	}
 
-	op, err := opFromClaim(claim.ActionUninstall, stateful, c, invocImage, creds, w)
+	op, err := opFromClaim(claim.ActionUninstall, stateful, c, invocImage, creds)
+	if err != nil {
+		return err
+	}
+
+	err = OperationConfigs(opCfgs).ApplyConfig(op)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/deislabs/cnab-go/action/upgrade.go
+++ b/vendor/github.com/deislabs/cnab-go/action/upgrade.go
@@ -1,8 +1,6 @@
 package action
 
 import (
-	"io"
-
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/credentials"
 	"github.com/deislabs/cnab-go/driver"
@@ -14,13 +12,18 @@ type Upgrade struct {
 }
 
 // Run performs the upgrade steps and updates the Claim
-func (u *Upgrade) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error {
+func (u *Upgrade) Run(c *claim.Claim, creds credentials.Set, opCfgs ...OperationConfigFunc) error {
 	invocImage, err := selectInvocationImage(u.Driver, c)
 	if err != nil {
 		return err
 	}
 
-	op, err := opFromClaim(claim.ActionUpgrade, stateful, c, invocImage, creds, w)
+	op, err := opFromClaim(claim.ActionUpgrade, stateful, c, invocImage, creds)
+	if err != nil {
+		return err
+	}
+
+	err = OperationConfigs(opCfgs).ApplyConfig(op)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/deislabs/cnab-go/bundle/definition/schema.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/definition/schema.go
@@ -31,19 +31,19 @@ type Schema struct {
 	Else                 *Schema                `json:"else,omitempty" yaml:"else,omitempty"`
 	Enum                 []interface{}          `json:"enum,omitempty" yaml:"enum,omitempty"`
 	Examples             []interface{}          `json:"examples,omitempty" yaml:"examples,omitempty"`
-	ExclusiveMaximum     *float64               `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
-	ExclusiveMinimum     *float64               `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	ExclusiveMaximum     *int                   `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	ExclusiveMinimum     *int                   `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
 	Format               string                 `json:"format,omitempty" yaml:"format,omitempty"`
 	If                   *Schema                `json:"if,omitempty" yaml:"if,omitempty"`
 	//Items can be a Schema or an Array of Schema :(
 	Items         interface{} `json:"items,omitempty" yaml:"items,omitempty"`
-	Maximum       *float64    `json:"maximum,omitempty" yaml:"maximum,omitempty"`
-	MaxLength     *float64    `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
-	MinItems      *float64    `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-	MinLength     *float64    `json:"minLength,omitempty" yaml:"minLength,omitempty"`
-	MinProperties *float64    `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
-	Minimum       *float64    `json:"minimum,omitempty" yaml:"minimum,omitempty"`
-	MultipleOf    *float64    `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	Maximum       *int        `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	MaxLength     *int        `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	MinItems      *int        `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	MinLength     *int        `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	MinProperties *int        `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
+	Minimum       *int        `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	MultipleOf    *int        `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 	Not           *Schema     `json:"not,omitempty" yaml:"not,omitempty"`
 	OneOf         *Schema     `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
 
@@ -121,12 +121,6 @@ func (s *Schema) ConvertValue(val string) (interface{}, error) {
 	switch dataType {
 	case "string":
 		return val, nil
-	case "number":
-		num, err := strconv.ParseFloat(val, 64)
-		if err != nil {
-			return nil, errors.Wrapf(err, "unable to convert %s to number", val)
-		}
-		return num, nil
 	case "integer":
 		return strconv.Atoi(val)
 	case "boolean":

--- a/vendor/github.com/deislabs/cnab-go/driver/docker/docker.go
+++ b/vendor/github.com/deislabs/cnab-go/driver/docker/docker.go
@@ -137,7 +137,7 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 		return driver.OperationResult{}, nil
 	}
 	if d.config["PULL_ALWAYS"] == "1" {
-		if err := pullImage(ctx, cli, op.Image); err != nil {
+		if err := pullImage(ctx, cli, op.Image.Image); err != nil {
 			return driver.OperationResult{}, err
 		}
 	}
@@ -147,7 +147,7 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 	}
 
 	cfg := &container.Config{
-		Image:        op.Image,
+		Image:        op.Image.Image,
 		Env:          env,
 		Entrypoint:   strslice.StrSlice{"/cnab/app/run"},
 		AttachStderr: true,
@@ -164,8 +164,8 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 	resp, err := cli.Client().ContainerCreate(ctx, cfg, hostCfg, nil, "")
 	switch {
 	case client.IsErrNotFound(err):
-		fmt.Fprintf(cli.Err(), "Unable to find image '%s' locally\n", op.Image)
-		if err := pullImage(ctx, cli, op.Image); err != nil {
+		fmt.Fprintf(cli.Err(), "Unable to find image '%s' locally\n", op.Image.Image)
+		if err := pullImage(ctx, cli, op.Image.Image); err != nil {
 			return driver.OperationResult{}, err
 		}
 		if resp, err = cli.Client().ContainerCreate(ctx, cfg, hostCfg, nil, ""); err != nil {

--- a/vendor/github.com/deislabs/cnab-go/driver/driver.go
+++ b/vendor/github.com/deislabs/cnab-go/driver/driver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/go/canonical/json"
 )
 
@@ -26,9 +27,7 @@ type Operation struct {
 	// Parameters are the parameters to be injected into the container
 	Parameters map[string]interface{} `json:"parameters"`
 	// Image is the invocation image
-	Image string `json:"image"`
-	// ImageType is the type of image.
-	ImageType string `json:"image_type"`
+	Image bundle.InvocationImage `json:"image"`
 	// Environment contains environment variables that should be injected into the invocation image
 	Environment map[string]string `json:"environment"`
 	// Files contains files that should be injected into the invocation image.

--- a/vendor/github.com/deislabs/cnab-go/driver/kubernetes/kubernetes.go
+++ b/vendor/github.com/deislabs/cnab-go/driver/kubernetes/kubernetes.go
@@ -12,6 +12,7 @@ import (
 	// Convert transitive deps to direct deps so that we can use constraints in our Gopkg.toml
 	_ "github.com/Azure/go-autorest/autorest"
 
+	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/driver"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -152,7 +153,7 @@ func (k *Driver) Run(op *driver.Operation) (driver.OperationResult, error) {
 	}
 	container := v1.Container{
 		Name:    k8sContainerName,
-		Image:   op.Image,
+		Image:   imageWithDigest(op.Image),
 		Command: []string{"/cnab/app/run"},
 		Resources: v1.ResourceRequirements{
 			Limits: v1.ResourceList{
@@ -377,4 +378,11 @@ func homeDir() string {
 		return h
 	}
 	return os.Getenv("USERPROFILE") // windows
+}
+
+func imageWithDigest(img bundle.InvocationImage) string {
+	if img.Digest == "" {
+		return img.Image
+	}
+	return img.Image + "@" + img.Digest
 }


### PR DESCRIPTION
See https://github.com/deislabs/cnab-go/releases/tag/v0.4.0-beta1

* Switch passing the writer to `Run` from a parameter to a configuration function.
* Switch from using `op.Image` to `op.Image.Image`
* Remove unused constraint that dep was complaining about