### PR TITLE
Add Urvashi Reddy as a maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,6 @@
 # Global Owners: These members are Core Maintainers of Duffle
 # Only certain critical files should cause all the owners to be added automatically to PR reviews
 # See https://github.com/deislabs/duffle/issues/745 for the rationale
-CODEOWNERS @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone
-LICENSE    @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone
-NOTICE     @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone
+CODEOWNERS @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone @youreddy
+LICENSE    @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone @youreddy
+NOTICE     @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone @youreddy


### PR DESCRIPTION
Pivotal's contributions for outputs in cnab-go and the Duffle driver were very important and they have indicated they will continue to be involved in the spec, as well as Duffle and cnab-go development, so I'd like to nominate Urvashi as a maintainer. She is also a cnab-spec approver!