### PR TITLE
Removing Matt Fisher from the CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,6 @@
 # Global Owners: These members are Core Maintainers of Duffle
 # Only certain critical files should cause all the owners to be added automatically to PR reviews
 # See https://github.com/deislabs/duffle/issues/745 for the rationale
-CODEOWNERS @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone @youreddy
-LICENSE    @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone @youreddy
-NOTICE     @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone @youreddy
+CODEOWNERS @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @glyn @silvin-lubecki @jlegrone @youreddy
+LICENSE    @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @glyn @silvin-lubecki @jlegrone @youreddy
+NOTICE     @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @glyn @silvin-lubecki @jlegrone @youreddy


### PR DESCRIPTION
Matt Fisher is no longer actively working on CNAB/Duffle, we thank you for your service @bacongobbler .